### PR TITLE
patch: default diff scope to show staged and unstaged changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,17 @@ pnpm cli serve                                  # Start MCP server
 - **Pipeline UI path:** `resolveUiRoot()` walks up from `import.meta.url` to workspace root — fragile if files move.
 - **MCP stdio safety:** Any console output during MCP mode corrupts the protocol. `silent: true` is critical.
 
+## UX Design Notes
+
+**`docs/ux-design-notes.md`** is a living document tracking user experience decisions, observations, and expected behavior. **Update it whenever:**
+
+- A default behavior changes (e.g., CLI flags, diff scope)
+- A UX pain point is discovered or fixed
+- A design decision is made about how the tool should feel or behave
+- The user reports friction or unexpected behavior during a session
+
+Add entries under the appropriate section with the version, rationale, and any linked issues.
+
 ## Roadmap
 
 ### M1: Usable Review Experience

--- a/cli/src/commands/review.ts
+++ b/cli/src/commands/review.ts
@@ -19,8 +19,8 @@ export async function review(
   } else if (ref) {
     diffRef = ref;
   } else {
-    // Default to staged if no ref specified
-    diffRef = "staged";
+    // Default to all changes (staged + unstaged) if no ref specified
+    diffRef = "all";
   }
 
   try {

--- a/docs/ux-design-notes.md
+++ b/docs/ux-design-notes.md
@@ -1,0 +1,48 @@
+# UX Design Notes
+
+Living document capturing user experience observations, design decisions, and expected behavior for DiffPrism. Updated continuously as the tool evolves.
+
+---
+
+## CLI Defaults
+
+### Default diff scope (v0.2.6)
+- **Decision:** `diffprism review` with no flags defaults to `"all"` (staged + unstaged via `git diff HEAD`)
+- **Rationale:** Most users edit files and run the review without staging first. Defaulting to `"staged"` caused "No changes to review" confusion. Explicit `--staged` and `--unstaged` flags still available for narrower scope.
+- **Issue:** [#6](https://github.com/CodeJonesW/diffprism/issues/6)
+
+---
+
+## Review UI
+
+### Current state (M0)
+- Dark mode only, GitHub dark theme colors
+- Unified diff view with syntax highlighting (refractor)
+- Two actions: Approve / Request Changes
+- No inline commenting yet
+
+### Observations
+- (Add observations here as they arise from real usage)
+
+---
+
+## MCP Integration
+
+### Setup simplicity (v0.2.x)
+- Published to npm so MCP config is just `npx diffprism serve` — no cloning, no path dependencies
+- `silent: true` is critical to prevent stdout from corrupting MCP stdio protocol
+
+---
+
+## Pain Points & Open Questions
+
+- (Capture friction points from real usage sessions here)
+
+---
+
+## Design Principles
+
+1. **Zero-config for common cases** — sensible defaults, flags for overrides
+2. **Fast feedback loop** — browser opens immediately, result returns as JSON
+3. **Local-first** — no accounts, no cloud, everything runs on the user's machine
+4. **Agent-friendly** — structured input/output, MCP integration, silent mode for automation

--- a/packages/git/src/local.ts
+++ b/packages/git/src/local.ts
@@ -39,6 +39,9 @@ export function getGitDiff(
     case "unstaged":
       command = "git diff --no-color";
       break;
+    case "all":
+      command = "git diff HEAD --no-color";
+      break;
     default:
       command = `git diff --no-color ${ref}`;
       break;


### PR DESCRIPTION

  Bug Fixes

  - Default diff scope now shows all changes — diffprism review with no flags now defaults to showing both
   staged and unstaged changes (git diff HEAD) instead of only staged changes. This fixes the common case
  where users edit files without staging and see "No changes to review." Explicit --staged and --unstaged
  flags still work for narrower scope. (#6)