### PR TITLE
patch: inject version from package.json at build time

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -4,12 +4,14 @@ import { Command } from "commander";
 import { review } from "./commands/review.js";
 import { serve } from "./commands/serve.js";
 
+declare const DIFFPRISM_VERSION: string;
+
 const program = new Command();
 
 program
   .name("diffprism")
   .description("Local-first code review tool for agent-generated changes")
-  .version("0.0.1");
+  .version(typeof DIFFPRISM_VERSION !== "undefined" ? DIFFPRISM_VERSION : "0.0.0-dev");
 
 program
   .command("review [ref]")

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,10 +3,12 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { startReview } from "@diffprism/core";
 
+declare const DIFFPRISM_VERSION: string;
+
 export async function startMcpServer(): Promise<void> {
   const server = new McpServer({
     name: "diffprism",
-    version: "0.0.1",
+    version: typeof DIFFPRISM_VERSION !== "undefined" ? DIFFPRISM_VERSION : "0.0.0-dev",
   });
 
   server.tool(

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from "tsup";
+import { readFileSync } from "fs";
+
+const { version } = JSON.parse(readFileSync("./package.json", "utf-8"));
 
 export default defineConfig({
   entry: {
@@ -11,6 +14,9 @@ export default defineConfig({
   outDir: "dist",
   splitting: true,
   clean: true,
+  define: {
+    DIFFPRISM_VERSION: JSON.stringify(version),
+  },
   // Inline all @diffprism/* workspace packages
   noExternal: [/@diffprism\/.*/],
   // Keep third-party deps external (installed from npm)


### PR DESCRIPTION
Replaces hardcoded "0.0.1" version strings in CLI and MCP server with a build-time constant injected by tsup from root package.json.

Closes #9