### PR TITLE
patch: include untracked files in unstaged and all diffs

### DIFF
--- a/packages/git/src/local.ts
+++ b/packages/git/src/local.ts
@@ -1,4 +1,6 @@
 import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 /**
  * Shell out to `git diff` and return the raw unified diff text.
@@ -32,31 +34,94 @@ export function getGitDiff(
 
   // Build the git diff command
   let command: string;
+  let includeUntracked = false;
   switch (ref) {
     case "staged":
       command = "git diff --staged --no-color";
       break;
     case "unstaged":
       command = "git diff --no-color";
+      includeUntracked = true;
       break;
     case "all":
       command = "git diff HEAD --no-color";
+      includeUntracked = true;
       break;
     default:
       command = `git diff --no-color ${ref}`;
       break;
   }
 
+  let output: string;
   try {
-    const output = execSync(command, {
+    output = execSync(command, {
       cwd,
       encoding: "utf-8",
       maxBuffer: 50 * 1024 * 1024, // 50 MB
     });
-    return output;
   } catch (err) {
     const message =
       err instanceof Error ? err.message : String(err);
     throw new Error(`git diff failed: ${message}`);
   }
+
+  if (includeUntracked) {
+    output += getUntrackedDiffs(cwd);
+  }
+
+  return output;
+}
+
+/**
+ * Find untracked files and generate unified diff output for each one,
+ * so they appear as "added" files in the parsed DiffSet.
+ */
+function getUntrackedDiffs(cwd: string): string {
+  let untrackedList: string;
+  try {
+    untrackedList = execSync(
+      "git ls-files --others --exclude-standard",
+      { cwd, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+    ).trim();
+  } catch {
+    return "";
+  }
+
+  if (!untrackedList) return "";
+
+  const files = untrackedList.split("\n");
+  let result = "";
+
+  for (const file of files) {
+    const absPath = path.resolve(cwd, file);
+    let content: string;
+    try {
+      content = readFileSync(absPath, "utf-8");
+    } catch {
+      // Binary or unreadable — skip
+      continue;
+    }
+
+    const lines = content.split("\n");
+    // If the file ends with a newline, the last split element is empty
+    const hasTrailingNewline =
+      content.length > 0 && content[content.length - 1] === "\n";
+    const contentLines = hasTrailingNewline ? lines.slice(0, -1) : lines;
+
+    result += `diff --git a/${file} b/${file}\n`;
+    result += "new file mode 100644\n";
+    result += "--- /dev/null\n";
+    result += `+++ b/${file}\n`;
+    result += `@@ -0,0 +1,${contentLines.length} @@\n`;
+
+    for (const line of contentLines) {
+      result += `+${line}\n`;
+    }
+
+    if (!hasTrailingNewline) {
+      result += "\\ No newline at end of file\n";
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
## What changed
Untracked (new) files now appear in the review UI when using `unstaged` or `all` diff refs. Added a `getUntrackedDiffs()` helper in `packages/git/src/local.ts` that discovers untracked files via `git ls-files --others --exclude-standard` and generates proper unified diff output that the existing parser already understands.

## Why
Closes #27 — `git diff` only operates on tracked files, so newly created files (common with agent-generated code) were invisible in the review UI.

## Testing
- `pnpm test` passes (all 18 tests)
- `pnpm run build` passes
- Manual: ran `pnpm cli review` with untracked files present — they now appear as "added" in the file browser and diff viewer

## Release notes
Untracked (new) files now appear in the review UI when diffing unstaged or all changes. Previously only tracked file modifications were shown.