### PR TITLE
patch: add unit test coverage for core, git, and CLI packages

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@diffprism/core": "workspace:*",
@@ -16,6 +17,7 @@
     "tsx": "^4.19.0"
   },
   "devDependencies": {
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/cli/src/__tests__/review.test.ts
+++ b/cli/src/__tests__/review.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock @diffprism/core before importing the review command
+vi.mock("@diffprism/core", () => ({
+  startReview: vi.fn(),
+}));
+
+import { review } from "../commands/review.js";
+import { startReview } from "@diffprism/core";
+
+const mockStartReview = vi.mocked(startReview);
+
+describe("review command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Prevent actual process.exit
+    vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  describe("flag resolution", () => {
+    it('resolves --staged flag to diffRef "staged"', async () => {
+      mockStartReview.mockResolvedValue({
+        decision: "approved",
+        comments: [],
+      });
+
+      await review(undefined, { staged: true });
+
+      expect(mockStartReview).toHaveBeenCalledWith(
+        expect.objectContaining({ diffRef: "staged" }),
+      );
+    });
+
+    it('resolves --unstaged flag to diffRef "unstaged"', async () => {
+      mockStartReview.mockResolvedValue({
+        decision: "approved",
+        comments: [],
+      });
+
+      await review(undefined, { unstaged: true });
+
+      expect(mockStartReview).toHaveBeenCalledWith(
+        expect.objectContaining({ diffRef: "unstaged" }),
+      );
+    });
+
+    it("resolves an explicit ref argument", async () => {
+      mockStartReview.mockResolvedValue({
+        decision: "approved",
+        comments: [],
+      });
+
+      await review("HEAD~3..HEAD", {});
+
+      expect(mockStartReview).toHaveBeenCalledWith(
+        expect.objectContaining({ diffRef: "HEAD~3..HEAD" }),
+      );
+    });
+
+    it('defaults to "all" when no ref or flags are provided', async () => {
+      mockStartReview.mockResolvedValue({
+        decision: "approved",
+        comments: [],
+      });
+
+      await review(undefined, {});
+
+      expect(mockStartReview).toHaveBeenCalledWith(
+        expect.objectContaining({ diffRef: "all" }),
+      );
+    });
+
+    it("--staged takes priority over a ref argument", async () => {
+      mockStartReview.mockResolvedValue({
+        decision: "approved",
+        comments: [],
+      });
+
+      await review("HEAD~1..HEAD", { staged: true });
+
+      expect(mockStartReview).toHaveBeenCalledWith(
+        expect.objectContaining({ diffRef: "staged" }),
+      );
+    });
+  });
+
+  describe("options passthrough", () => {
+    it("passes title and dev flag to startReview", async () => {
+      mockStartReview.mockResolvedValue({
+        decision: "approved",
+        comments: [],
+      });
+
+      await review(undefined, {
+        staged: true,
+        title: "My Review",
+        dev: true,
+      });
+
+      expect(mockStartReview).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "My Review",
+          dev: true,
+        }),
+      );
+    });
+  });
+
+  describe("output and exit", () => {
+    it("prints JSON result and exits 0 on success", async () => {
+      const result = {
+        decision: "approved" as const,
+        comments: [],
+        summary: "LGTM",
+      };
+      mockStartReview.mockResolvedValue(result);
+
+      await review(undefined, { staged: true });
+
+      expect(console.log).toHaveBeenCalledWith(
+        JSON.stringify(result, null, 2),
+      );
+      expect(process.exit).toHaveBeenCalledWith(0);
+    });
+
+    it("prints error message and exits 1 on failure", async () => {
+      mockStartReview.mockRejectedValue(new Error("git not found"));
+
+      await review(undefined, { staged: true });
+
+      expect(console.error).toHaveBeenCalledWith("Error: git not found");
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/packages/core/src/__tests__/review-manager.test.ts
+++ b/packages/core/src/__tests__/review-manager.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  createSession,
+  getSession,
+  updateSession,
+  deleteSession,
+} from "../review-manager.js";
+
+describe("review-manager", () => {
+  // Each createSession call gets a unique ID via the internal counter,
+  // so we don't need to reset module state between tests — just clean up.
+
+  describe("createSession", () => {
+    it("returns a session with a unique ID matching expected format", () => {
+      const session = createSession({ diffRef: "staged" });
+      expect(session.id).toMatch(/^review-\d+-\d+$/);
+      expect(session.status).toBe("pending");
+      expect(session.options.diffRef).toBe("staged");
+      expect(session.createdAt).toBeTypeOf("number");
+      expect(session.result).toBeUndefined();
+
+      // Clean up
+      deleteSession(session.id);
+    });
+
+    it("generates unique IDs across calls", () => {
+      const s1 = createSession({ diffRef: "staged" });
+      const s2 = createSession({ diffRef: "unstaged" });
+      expect(s1.id).not.toBe(s2.id);
+
+      deleteSession(s1.id);
+      deleteSession(s2.id);
+    });
+
+    it("stores the session so getSession can retrieve it", () => {
+      const session = createSession({ diffRef: "HEAD~1..HEAD" });
+      const retrieved = getSession(session.id);
+      expect(retrieved).toBe(session);
+
+      deleteSession(session.id);
+    });
+  });
+
+  describe("getSession", () => {
+    it("returns undefined for a non-existent ID", () => {
+      expect(getSession("review-nonexistent-999")).toBeUndefined();
+    });
+  });
+
+  describe("updateSession", () => {
+    it("updates status on an existing session", () => {
+      const session = createSession({ diffRef: "staged" });
+      updateSession(session.id, { status: "in_progress" });
+
+      const retrieved = getSession(session.id);
+      expect(retrieved?.status).toBe("in_progress");
+
+      deleteSession(session.id);
+    });
+
+    it("updates result on an existing session", () => {
+      const session = createSession({ diffRef: "staged" });
+      const result = {
+        decision: "approved" as const,
+        comments: [],
+        summary: "Looks good",
+      };
+      updateSession(session.id, { status: "completed", result });
+
+      const retrieved = getSession(session.id);
+      expect(retrieved?.status).toBe("completed");
+      expect(retrieved?.result).toEqual(result);
+
+      deleteSession(session.id);
+    });
+
+    it("does nothing for a non-existent session", () => {
+      // Should not throw
+      updateSession("review-nonexistent-999", { status: "completed" });
+    });
+  });
+
+  describe("deleteSession", () => {
+    it("removes a session so getSession returns undefined", () => {
+      const session = createSession({ diffRef: "staged" });
+      deleteSession(session.id);
+      expect(getSession(session.id)).toBeUndefined();
+    });
+
+    it("does nothing for a non-existent session", () => {
+      // Should not throw
+      deleteSession("review-nonexistent-999");
+    });
+  });
+});

--- a/packages/core/src/__tests__/ws-bridge.test.ts
+++ b/packages/core/src/__tests__/ws-bridge.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { WebSocket } from "ws";
+import { createWsBridge } from "../ws-bridge.js";
+import type { WsBridge } from "../ws-bridge.js";
+import type {
+  ReviewInitPayload,
+  ServerMessage,
+  ClientMessage,
+} from "../types.js";
+
+const TEST_PORT = 9871;
+
+function makeInitPayload(): ReviewInitPayload {
+  return {
+    reviewId: "test-review-1",
+    diffSet: { baseRef: "HEAD", headRef: "staged", files: [] },
+    rawDiff: "",
+    briefing: {
+      summary: "Test",
+      triage: { critical: [], notable: [], mechanical: [] },
+      impact: {
+        affectedModules: [],
+        affectedTests: [],
+        publicApiChanges: false,
+        breakingChanges: [],
+        newDependencies: [],
+      },
+      verification: { testsPass: null, typeCheck: null, lintClean: null },
+      fileStats: [],
+    },
+    metadata: {},
+  };
+}
+
+/**
+ * Connect a WS client and capture the first message (if any) that arrives
+ * during or immediately after the handshake.
+ */
+function connectClient(port: number): {
+  ws: Promise<WebSocket>;
+  firstMessage: Promise<ServerMessage>;
+} {
+  const ws = new WebSocket(`ws://localhost:${port}`);
+  const firstMessage = new Promise<ServerMessage>((resolve) => {
+    ws.once("message", (data) => {
+      resolve(JSON.parse(data.toString()));
+    });
+  });
+  const ready = new Promise<WebSocket>((resolve, reject) => {
+    ws.on("open", () => resolve(ws));
+    ws.on("error", reject);
+  });
+  return { ws: ready, firstMessage };
+}
+
+describe("ws-bridge", () => {
+  let bridge: WsBridge;
+
+  afterEach(() => {
+    bridge?.close();
+  });
+
+  it("sends pending init payload when client connects after sendInit", async () => {
+    bridge = createWsBridge(TEST_PORT);
+    const payload = makeInitPayload();
+
+    // Send init before any client is connected — stored as pending
+    bridge.sendInit(payload);
+
+    // Connect — message listener is registered before open, so we catch it
+    const { ws, firstMessage } = connectClient(TEST_PORT);
+    const client = await ws;
+    const msg = await firstMessage;
+
+    expect(msg.type).toBe("review:init");
+    expect(msg.payload.reviewId).toBe("test-review-1");
+
+    client.close();
+  });
+
+  it("sends init payload immediately if client is already connected", async () => {
+    bridge = createWsBridge(TEST_PORT);
+    const payload = makeInitPayload();
+
+    const { ws } = connectClient(TEST_PORT);
+    const client = await ws;
+
+    // Small delay to ensure connection is registered on bridge side
+    await new Promise((r) => setTimeout(r, 50));
+
+    const msgPromise = new Promise<ServerMessage>((resolve) => {
+      client.once("message", (data) => {
+        resolve(JSON.parse(data.toString()));
+      });
+    });
+    bridge.sendInit(payload);
+    const msg = await msgPromise;
+
+    expect(msg.type).toBe("review:init");
+    expect(msg.payload.reviewId).toBe("test-review-1");
+
+    client.close();
+  });
+
+  it("resolves waitForResult when client sends review:submit", async () => {
+    bridge = createWsBridge(TEST_PORT);
+
+    const resultPromise = bridge.waitForResult();
+
+    const { ws } = connectClient(TEST_PORT);
+    const client = await ws;
+
+    const submitMsg: ClientMessage = {
+      type: "review:submit",
+      payload: {
+        decision: "approved",
+        comments: [],
+        summary: "LGTM",
+      },
+    };
+    client.send(JSON.stringify(submitMsg));
+
+    const result = await resultPromise;
+    expect(result.decision).toBe("approved");
+    expect(result.summary).toBe("LGTM");
+
+    client.close();
+  });
+
+  it("ignores malformed messages without crashing", async () => {
+    bridge = createWsBridge(TEST_PORT);
+
+    const { ws } = connectClient(TEST_PORT);
+    const client = await ws;
+
+    // Send garbage — should not throw or crash the bridge
+    client.send("not-json");
+    client.send(JSON.stringify({ type: "unknown" }));
+
+    // Bridge should still be functional — send a valid submit
+    const resultPromise = bridge.waitForResult();
+    const submitMsg: ClientMessage = {
+      type: "review:submit",
+      payload: {
+        decision: "changes_requested",
+        comments: [],
+      },
+    };
+    client.send(JSON.stringify(submitMsg));
+
+    const result = await resultPromise;
+    expect(result.decision).toBe("changes_requested");
+
+    client.close();
+  });
+
+  it("replays init payload on reconnect", async () => {
+    bridge = createWsBridge(TEST_PORT);
+    const payload = makeInitPayload();
+
+    bridge.sendInit(payload);
+
+    // First client connects, receives init
+    const conn1 = connectClient(TEST_PORT);
+    const client1 = await conn1.ws;
+    const msg1 = await conn1.firstMessage;
+    expect(msg1.type).toBe("review:init");
+
+    // First client disconnects
+    client1.close();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Second client connects — should get init replayed
+    const conn2 = connectClient(TEST_PORT);
+    const client2 = await conn2.ws;
+    const msg2 = await conn2.firstMessage;
+    expect(msg2.type).toBe("review:init");
+    expect(msg2.payload.reviewId).toBe("test-review-1");
+
+    client2.close();
+  });
+
+  it("rejects waitForResult if client disconnects and no reconnect within grace period", async () => {
+    bridge = createWsBridge(TEST_PORT);
+
+    const resultPromise = bridge.waitForResult();
+
+    const { ws } = connectClient(TEST_PORT);
+    const client = await ws;
+    // Close immediately without submitting
+    client.close();
+
+    // Wait longer than the 2s grace period
+    await expect(resultPromise).rejects.toThrow(
+      "Browser closed before review was submitted",
+    );
+  }, 10000);
+
+  it("does not reject if a new client reconnects within the grace period", async () => {
+    bridge = createWsBridge(TEST_PORT);
+    const payload = makeInitPayload();
+    bridge.sendInit(payload);
+
+    const resultPromise = bridge.waitForResult();
+
+    // First client connects then disconnects
+    const conn1 = connectClient(TEST_PORT);
+    const client1 = await conn1.ws;
+    await conn1.firstMessage; // consume init
+    client1.close();
+
+    // Reconnect within the 2s grace period
+    await new Promise((r) => setTimeout(r, 500));
+    const conn2 = connectClient(TEST_PORT);
+    const client2 = await conn2.ws;
+    await conn2.firstMessage; // consume replayed init
+
+    // Submit from second client
+    const submitMsg: ClientMessage = {
+      type: "review:submit",
+      payload: {
+        decision: "approved_with_comments",
+        comments: [],
+        summary: "Reconnected and approved",
+      },
+    };
+    client2.send(JSON.stringify(submitMsg));
+
+    const result = await resultPromise;
+    expect(result.decision).toBe("approved_with_comments");
+
+    client2.close();
+  });
+});

--- a/packages/git/src/__tests__/get-diff.test.ts
+++ b/packages/git/src/__tests__/get-diff.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock the local and parser modules before importing getDiff
+vi.mock("../local.js", () => ({
+  getGitDiff: vi.fn(),
+}));
+
+vi.mock("../parser.js", () => ({
+  parseDiff: vi.fn(),
+}));
+
+import { getDiff } from "../index.js";
+import { getGitDiff } from "../local.js";
+import { parseDiff } from "../parser.js";
+
+const mockGetGitDiff = vi.mocked(getGitDiff);
+const mockParseDiff = vi.mocked(parseDiff);
+
+const emptyDiffSet = { baseRef: "", headRef: "", files: [] };
+
+describe("getDiff", () => {
+  describe("ref label derivation", () => {
+    it('derives baseRef="HEAD", headRef="staged" for ref "staged"', () => {
+      mockGetGitDiff.mockReturnValue("raw diff");
+      mockParseDiff.mockReturnValue(emptyDiffSet);
+
+      getDiff("staged");
+
+      expect(mockParseDiff).toHaveBeenCalledWith("raw diff", "HEAD", "staged");
+    });
+
+    it('derives baseRef="staged", headRef="working tree" for ref "unstaged"', () => {
+      mockGetGitDiff.mockReturnValue("raw diff");
+      mockParseDiff.mockReturnValue(emptyDiffSet);
+
+      getDiff("unstaged");
+
+      expect(mockParseDiff).toHaveBeenCalledWith(
+        "raw diff",
+        "staged",
+        "working tree",
+      );
+    });
+
+    it("splits ref ranges at .. for baseRef and headRef", () => {
+      mockGetGitDiff.mockReturnValue("raw diff");
+      mockParseDiff.mockReturnValue(emptyDiffSet);
+
+      getDiff("main..feature");
+
+      expect(mockParseDiff).toHaveBeenCalledWith(
+        "raw diff",
+        "main",
+        "feature",
+      );
+    });
+
+    it("handles three-dot range by splitting at first ..", () => {
+      mockGetGitDiff.mockReturnValue("raw diff");
+      mockParseDiff.mockReturnValue(emptyDiffSet);
+
+      getDiff("HEAD~3..HEAD");
+
+      expect(mockParseDiff).toHaveBeenCalledWith(
+        "raw diff",
+        "HEAD~3",
+        "HEAD",
+      );
+    });
+
+    it('uses ref as baseRef and "HEAD" as headRef for plain refs', () => {
+      mockGetGitDiff.mockReturnValue("raw diff");
+      mockParseDiff.mockReturnValue(emptyDiffSet);
+
+      getDiff("abc123");
+
+      expect(mockParseDiff).toHaveBeenCalledWith(
+        "raw diff",
+        "abc123",
+        "HEAD",
+      );
+    });
+  });
+
+  describe("return value", () => {
+    it("returns both rawDiff and diffSet", () => {
+      const fakeDiffSet = {
+        baseRef: "HEAD",
+        headRef: "staged",
+        files: [
+          {
+            path: "test.ts",
+            status: "modified" as const,
+            hunks: [],
+            language: "typescript",
+            binary: false,
+            additions: 1,
+            deletions: 0,
+          },
+        ],
+      };
+      mockGetGitDiff.mockReturnValue("the raw diff");
+      mockParseDiff.mockReturnValue(fakeDiffSet);
+
+      const result = getDiff("staged");
+
+      expect(result.rawDiff).toBe("the raw diff");
+      expect(result.diffSet).toBe(fakeDiffSet);
+    });
+  });
+
+  describe("cwd passthrough", () => {
+    it("forwards cwd option to getGitDiff", () => {
+      mockGetGitDiff.mockReturnValue("");
+      mockParseDiff.mockReturnValue(emptyDiffSet);
+
+      getDiff("staged", { cwd: "/some/path" });
+
+      expect(mockGetGitDiff).toHaveBeenCalledWith("staged", {
+        cwd: "/some/path",
+      });
+    });
+  });
+});

--- a/packages/git/src/__tests__/local.test.ts
+++ b/packages/git/src/__tests__/local.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getGitDiff } from "../local.js";
+
+// Mock child_process and fs
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(),
+}));
+
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const mockExecSync = vi.mocked(execSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+
+/**
+ * Set up execSync to pass git --version and git rev-parse checks,
+ * then return the given diff output for the actual diff command.
+ */
+function setupGitMocks(diffOutput: string, untrackedList = "") {
+  mockExecSync.mockImplementation((cmd: string, _opts?: unknown) => {
+    const command = String(cmd);
+    if (command === "git --version") return "git version 2.40.0";
+    if (command === "git rev-parse --is-inside-work-tree") return "true";
+    if (command === "git ls-files --others --exclude-standard")
+      return untrackedList;
+    // Any git diff command
+    if (command.startsWith("git diff")) return diffOutput;
+    return "";
+  });
+}
+
+describe("getGitDiff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("ref to command mapping", () => {
+    it('maps "staged" to git diff --staged --no-color', () => {
+      setupGitMocks("staged diff output");
+      const result = getGitDiff("staged");
+
+      const diffCall = mockExecSync.mock.calls.find(
+        (c) => String(c[0]).startsWith("git diff"),
+      );
+      expect(String(diffCall?.[0])).toBe("git diff --staged --no-color");
+      expect(result).toBe("staged diff output");
+    });
+
+    it('maps "unstaged" to git diff --no-color and includes untracked', () => {
+      setupGitMocks("unstaged diff output", "");
+      const result = getGitDiff("unstaged");
+
+      const diffCall = mockExecSync.mock.calls.find(
+        (c) => String(c[0]) === "git diff --no-color",
+      );
+      expect(diffCall).toBeDefined();
+      expect(result).toBe("unstaged diff output");
+    });
+
+    it('maps "all" to git diff HEAD --no-color and includes untracked', () => {
+      setupGitMocks("all diff output", "");
+      const result = getGitDiff("all");
+
+      const diffCall = mockExecSync.mock.calls.find(
+        (c) => String(c[0]) === "git diff HEAD --no-color",
+      );
+      expect(diffCall).toBeDefined();
+      expect(result).toBe("all diff output");
+    });
+
+    it("maps a custom ref range to git diff --no-color <ref>", () => {
+      setupGitMocks("custom diff output");
+      const result = getGitDiff("HEAD~3..HEAD");
+
+      const diffCall = mockExecSync.mock.calls.find(
+        (c) => String(c[0]).startsWith("git diff --no-color"),
+      );
+      expect(String(diffCall?.[0])).toBe(
+        "git diff --no-color HEAD~3..HEAD",
+      );
+      expect(result).toBe("custom diff output");
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws when git is not available", () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (String(cmd) === "git --version") throw new Error("not found");
+        return "";
+      });
+
+      expect(() => getGitDiff("staged")).toThrow(
+        "git is not available",
+      );
+    });
+
+    it("throws when not inside a git repository", () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (String(cmd) === "git --version") return "git version 2.40.0";
+        if (String(cmd) === "git rev-parse --is-inside-work-tree")
+          throw new Error("not a repo");
+        return "";
+      });
+
+      expect(() => getGitDiff("staged")).toThrow(
+        "is not inside a git repository",
+      );
+    });
+
+    it("throws with a descriptive message when git diff fails", () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        const command = String(cmd);
+        if (command === "git --version") return "git version 2.40.0";
+        if (command === "git rev-parse --is-inside-work-tree") return "true";
+        if (command.startsWith("git diff"))
+          throw new Error("fatal: bad revision");
+        return "";
+      });
+
+      expect(() => getGitDiff("nonexistent..HEAD")).toThrow(
+        "git diff failed",
+      );
+    });
+  });
+
+  describe("untracked files", () => {
+    it('appends untracked file diffs for "unstaged" ref', () => {
+      mockReadFileSync.mockReturnValue("line one\nline two\n");
+      setupGitMocks("tracked diff\n", "newfile.ts");
+
+      const result = getGitDiff("unstaged");
+
+      expect(result).toContain("tracked diff");
+      expect(result).toContain("diff --git a/newfile.ts b/newfile.ts");
+      expect(result).toContain("new file mode 100644");
+      expect(result).toContain("+line one");
+      expect(result).toContain("+line two");
+    });
+
+    it('appends untracked file diffs for "all" ref', () => {
+      mockReadFileSync.mockReturnValue("content\n");
+      setupGitMocks("", "untracked.js");
+
+      const result = getGitDiff("all");
+
+      expect(result).toContain("diff --git a/untracked.js b/untracked.js");
+    });
+
+    it('does NOT include untracked files for "staged" ref', () => {
+      setupGitMocks("staged diff");
+
+      const result = getGitDiff("staged");
+
+      // Should not call git ls-files
+      const lsFilesCall = mockExecSync.mock.calls.find(
+        (c) => String(c[0]).includes("ls-files"),
+      );
+      expect(lsFilesCall).toBeUndefined();
+      expect(result).toBe("staged diff");
+    });
+
+    it("handles files without trailing newline", () => {
+      mockReadFileSync.mockReturnValue("no trailing newline");
+      setupGitMocks("", "notrail.txt");
+
+      const result = getGitDiff("unstaged");
+
+      expect(result).toContain("+no trailing newline");
+      expect(result).toContain("\\ No newline at end of file");
+    });
+
+    it("skips unreadable files gracefully", () => {
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error("binary file");
+      });
+      setupGitMocks("", "binary.bin");
+
+      const result = getGitDiff("unstaged");
+
+      // Should not crash, just skip the unreadable file
+      expect(result).not.toContain("binary.bin");
+    });
+  });
+
+  describe("cwd option", () => {
+    it("passes cwd to execSync", () => {
+      setupGitMocks("");
+      getGitDiff("staged", { cwd: "/tmp/my-repo" });
+
+      for (const call of mockExecSync.mock.calls) {
+        const opts = call[1] as { cwd?: string } | undefined;
+        expect(opts?.cwd).toBe("/tmp/my-repo");
+      }
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0)
 
   packages/analysis:
     dependencies:


### PR DESCRIPTION
## What changed
- Added 44 unit tests across 5 new test files covering previously untested modules:
  - `packages/core`: review-manager (9 tests), ws-bridge (7 tests)
  - `packages/git`: local.ts (13 tests), getDiff index.ts (7 tests)
  - `cli`: review command (8 tests)
- Added vitest as a devDependency to the CLI package
- Total test count: 34 → 78

## Why
Closes #16 — The codebase had test coverage only for the diff parser and deterministic analysis. Core infrastructure (session management, WebSocket bridge, git execution, CLI flag resolution) was untested.

## Testing
- `pnpm test` passes (78/78 tests)
- `pnpm run build` passes

## Release notes
Added 44 unit tests covering core, git, and CLI packages. Test coverage now spans review session management, WebSocket bridge, git diff execution, ref label derivation, and CLI flag resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)