### PR TITLE
minor: Add file-level review status tracking

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -38,6 +38,12 @@ export type ReviewDecision =
   | "changes_requested"
   | "approved_with_comments";
 
+export type FileReviewStatus =
+  | "unreviewed"
+  | "reviewed"
+  | "approved"
+  | "needs_changes";
+
 export interface ReviewComment {
   file: string;
   line: number;
@@ -48,6 +54,7 @@ export interface ReviewComment {
 export interface ReviewResult {
   decision: ReviewDecision;
   comments: ReviewComment[];
+  fileStatuses?: Record<string, FileReviewStatus>;
   summary?: string;
 }
 

--- a/packages/ui/src/components/ActionBar/ActionBar.tsx
+++ b/packages/ui/src/components/ActionBar/ActionBar.tsx
@@ -9,7 +9,7 @@ interface ActionBarProps {
 
 export function ActionBar({ onSubmit }: ActionBarProps) {
   const [summary, setSummary] = useState("");
-  const { diffSet } = useReviewStore();
+  const { diffSet, fileStatuses } = useReviewStore();
 
   const totalAdditions =
     diffSet?.files.reduce((sum, f) => sum + f.additions, 0) ?? 0;
@@ -18,9 +18,13 @@ export function ActionBar({ onSubmit }: ActionBarProps) {
   const fileCount = diffSet?.files.length ?? 0;
 
   function handleSubmit(decision: ReviewDecision) {
+    const hasStatuses = Object.values(fileStatuses).some(
+      (s) => s !== "unreviewed",
+    );
     onSubmit({
       decision,
       comments: [],
+      fileStatuses: hasStatuses ? fileStatuses : undefined,
       summary: summary.trim() || undefined,
     });
   }

--- a/packages/ui/src/store/review.ts
+++ b/packages/ui/src/store/review.ts
@@ -1,10 +1,19 @@
 import { create } from "zustand";
 import type {
   DiffSet,
+  FileReviewStatus,
   ReviewBriefing,
+  ReviewComment,
   ReviewInitPayload,
   ReviewMetadata,
 } from "../types";
+
+const FILE_STATUS_CYCLE: FileReviewStatus[] = [
+  "unreviewed",
+  "reviewed",
+  "approved",
+  "needs_changes",
+];
 
 export interface ReviewState {
   reviewId: string | null;
@@ -15,15 +24,24 @@ export interface ReviewState {
   selectedFile: string | null;
   connectionStatus: "connecting" | "connected" | "disconnected";
   viewMode: "unified" | "split";
+  fileStatuses: Record<string, FileReviewStatus>;
+  comments: ReviewComment[];
+  activeCommentKey: string | null;
 
   // Actions
   initReview: (payload: ReviewInitPayload) => void;
   selectFile: (path: string) => void;
   setConnectionStatus: (status: ReviewState["connectionStatus"]) => void;
   setViewMode: (mode: "unified" | "split") => void;
+  setFileStatus: (path: string, status: FileReviewStatus) => void;
+  cycleFileStatus: (path: string) => void;
+  addComment: (comment: ReviewComment) => void;
+  updateComment: (index: number, comment: ReviewComment) => void;
+  deleteComment: (index: number) => void;
+  setActiveCommentKey: (key: string | null) => void;
 }
 
-export const useReviewStore = create<ReviewState>((set) => ({
+export const useReviewStore = create<ReviewState>((set, get) => ({
   reviewId: null,
   diffSet: null,
   rawDiff: null,
@@ -32,12 +50,20 @@ export const useReviewStore = create<ReviewState>((set) => ({
   selectedFile: null,
   connectionStatus: "connecting",
   viewMode: "unified",
+  fileStatuses: {},
+  comments: [],
+  activeCommentKey: null,
 
   initReview: (payload: ReviewInitPayload) => {
     const firstFile =
       payload.diffSet.files.length > 0
         ? payload.diffSet.files[0].path
         : null;
+
+    const fileStatuses: Record<string, FileReviewStatus> = {};
+    for (const file of payload.diffSet.files) {
+      fileStatuses[file.path] = "unreviewed";
+    }
 
     set({
       reviewId: payload.reviewId,
@@ -46,6 +72,9 @@ export const useReviewStore = create<ReviewState>((set) => ({
       briefing: payload.briefing,
       metadata: payload.metadata,
       selectedFile: firstFile,
+      fileStatuses,
+      comments: [],
+      activeCommentKey: null,
     });
   },
 
@@ -59,5 +88,43 @@ export const useReviewStore = create<ReviewState>((set) => ({
 
   setViewMode: (mode: "unified" | "split") => {
     set({ viewMode: mode });
+  },
+
+  setFileStatus: (path: string, status: FileReviewStatus) => {
+    set((state) => ({
+      fileStatuses: { ...state.fileStatuses, [path]: status },
+    }));
+  },
+
+  cycleFileStatus: (path: string) => {
+    const current = get().fileStatuses[path] ?? "unreviewed";
+    const currentIndex = FILE_STATUS_CYCLE.indexOf(current);
+    const nextIndex = (currentIndex + 1) % FILE_STATUS_CYCLE.length;
+    set((state) => ({
+      fileStatuses: {
+        ...state.fileStatuses,
+        [path]: FILE_STATUS_CYCLE[nextIndex],
+      },
+    }));
+  },
+
+  addComment: (comment: ReviewComment) => {
+    set((state) => ({ comments: [...state.comments, comment] }));
+  },
+
+  updateComment: (index: number, comment: ReviewComment) => {
+    set((state) => ({
+      comments: state.comments.map((c, i) => (i === index ? comment : c)),
+    }));
+  },
+
+  deleteComment: (index: number) => {
+    set((state) => ({
+      comments: state.comments.filter((_, i) => i !== index),
+    }));
+  },
+
+  setActiveCommentKey: (key: string | null) => {
+    set({ activeCommentKey: key });
   },
 }));

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -39,6 +39,12 @@ export type ReviewDecision =
   | "changes_requested"
   | "approved_with_comments";
 
+export type FileReviewStatus =
+  | "unreviewed"
+  | "reviewed"
+  | "approved"
+  | "needs_changes";
+
 export interface ReviewComment {
   file: string;
   line: number;
@@ -49,6 +55,7 @@ export interface ReviewComment {
 export interface ReviewResult {
   decision: ReviewDecision;
   comments: ReviewComment[];
+  fileStatuses?: Record<string, FileReviewStatus>;
   summary?: string;
 }
 

--- a/ui-dist/index.html
+++ b/ui-dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DiffPrism</title>
-    <script type="module" crossorigin src="/assets/index-D7dYnICN.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BI0K_TCB.css">
+    <script type="module" crossorigin src="/assets/index-D_t2y2BP.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CwE0rW9A.css">
   </head>
   <body style="background-color: #0d1117; margin: 0;">
     <div id="root"></div>


### PR DESCRIPTION
## What changed

- Added `FileReviewStatus` type (`unreviewed | reviewed | approved | needs_changes`) to core and UI types
- Extended Zustand store with `fileStatuses` state, `setFileStatus`, and `cycleFileStatus` actions
- Added per-file review status icons in the FileBrowser sidebar:
  - **Unreviewed**: ghost Eye icon (visible on hover)
  - **Reviewed**: Eye icon (blue)
  - **Approved**: CheckCircle icon (green)
  - **Needs changes**: AlertCircle icon (yellow)
- Click the status icon or press `s` to cycle through statuses
- File statuses included in `ReviewResult` payload on submission (only when at least one file has been marked)

## Why

Closes #19 — Reviewers had no way to track which files they'd already looked at during a review. This adds lightweight per-file status tracking to the file browser.

## Testing

- `pnpm test` passes (78 tests)
- `pnpm run build` passes
- Reviewed with diffprism (`open_review`)