### PR TITLE
minor: Add inline line-level commenting and file-level review status

### DIFF
--- a/packages/ui/src/components/ActionBar/ActionBar.tsx
+++ b/packages/ui/src/components/ActionBar/ActionBar.tsx
@@ -9,7 +9,7 @@ interface ActionBarProps {
 
 export function ActionBar({ onSubmit }: ActionBarProps) {
   const [summary, setSummary] = useState("");
-  const { diffSet, fileStatuses } = useReviewStore();
+  const { diffSet, fileStatuses, comments } = useReviewStore();
 
   const totalAdditions =
     diffSet?.files.reduce((sum, f) => sum + f.additions, 0) ?? 0;
@@ -23,7 +23,7 @@ export function ActionBar({ onSubmit }: ActionBarProps) {
     );
     onSubmit({
       decision,
-      comments: [],
+      comments,
       fileStatuses: hasStatuses ? fileStatuses : undefined,
       summary: summary.trim() || undefined,
     });
@@ -44,6 +44,12 @@ export function ActionBar({ onSubmit }: ActionBarProps) {
         {totalDeletions > 0 && (
           <span className="text-red-400 text-xs font-mono">
             -{totalDeletions}
+          </span>
+        )}
+        {comments.length > 0 && (
+          <span className="flex items-center gap-1 text-accent text-xs">
+            <MessageSquare className="w-3 h-3" />
+            {comments.length} comment{comments.length !== 1 ? "s" : ""}
           </span>
         )}
       </div>

--- a/packages/ui/src/components/InlineComment/InlineCommentForm.tsx
+++ b/packages/ui/src/components/InlineComment/InlineCommentForm.tsx
@@ -1,0 +1,85 @@
+import { useState, useRef, useEffect } from "react";
+import type { ReviewComment } from "../../types";
+
+type CommentType = ReviewComment["type"];
+
+const COMMENT_TYPES: { value: CommentType; label: string }[] = [
+  { value: "suggestion", label: "Suggestion" },
+  { value: "must_fix", label: "Must Fix" },
+  { value: "question", label: "Question" },
+  { value: "nitpick", label: "Nitpick" },
+];
+
+interface InlineCommentFormProps {
+  onSave: (body: string, type: CommentType) => void;
+  onCancel: () => void;
+  initialBody?: string;
+  initialType?: CommentType;
+}
+
+export function InlineCommentForm({
+  onSave,
+  onCancel,
+  initialBody = "",
+  initialType = "suggestion",
+}: InlineCommentFormProps) {
+  const [body, setBody] = useState(initialBody);
+  const [type, setType] = useState<CommentType>(initialType);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      if (body.trim()) {
+        onSave(body.trim(), type);
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onCancel();
+    }
+  }
+
+  return (
+    <div className="p-3 space-y-2" onKeyDown={handleKeyDown}>
+      <textarea
+        ref={textareaRef}
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Write a comment..."
+        rows={3}
+        className="w-full bg-background border border-border rounded px-3 py-2 text-text-primary text-sm placeholder:text-text-secondary/50 resize-none focus:outline-none focus:ring-1 focus:ring-accent focus:border-accent"
+      />
+      <div className="flex items-center gap-2">
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value as CommentType)}
+          className="bg-background border border-border rounded px-2 py-1.5 text-text-primary text-xs focus:outline-none focus:ring-1 focus:ring-accent cursor-pointer"
+        >
+          {COMMENT_TYPES.map((ct) => (
+            <option key={ct.value} value={ct.value}>
+              {ct.label}
+            </option>
+          ))}
+        </select>
+        <div className="flex-1" />
+        <button
+          onClick={onCancel}
+          className="px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary transition-colors cursor-pointer"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={() => body.trim() && onSave(body.trim(), type)}
+          disabled={!body.trim()}
+          className="px-3 py-1.5 text-xs font-medium rounded bg-accent/20 text-accent border border-accent/30 hover:bg-accent/30 disabled:opacity-40 disabled:cursor-not-allowed transition-colors cursor-pointer"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/InlineComment/InlineCommentThread.tsx
+++ b/packages/ui/src/components/InlineComment/InlineCommentThread.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { Pencil, Trash2, Plus } from "lucide-react";
+import type { ReviewComment } from "../../types";
+import { InlineCommentForm } from "./InlineCommentForm";
+
+const TYPE_STYLES: Record<ReviewComment["type"], string> = {
+  must_fix: "bg-red-600/20 text-red-400 border-red-500/30",
+  suggestion: "bg-yellow-600/20 text-yellow-400 border-yellow-500/30",
+  question: "bg-blue-600/20 text-blue-400 border-blue-500/30",
+  nitpick: "bg-gray-600/20 text-gray-400 border-gray-500/30",
+};
+
+const TYPE_LABELS: Record<ReviewComment["type"], string> = {
+  must_fix: "Must Fix",
+  suggestion: "Suggestion",
+  question: "Question",
+  nitpick: "Nitpick",
+};
+
+interface InlineCommentThreadProps {
+  comments: { comment: ReviewComment; index: number }[];
+  isFormOpen: boolean;
+  file: string;
+  line: number;
+  onAdd: (body: string, type: ReviewComment["type"]) => void;
+  onUpdate: (index: number, body: string, type: ReviewComment["type"]) => void;
+  onDelete: (index: number) => void;
+  onOpenForm: () => void;
+  onCloseForm: () => void;
+}
+
+export function InlineCommentThread({
+  comments,
+  isFormOpen,
+  file,
+  line,
+  onAdd,
+  onUpdate,
+  onDelete,
+  onOpenForm,
+  onCloseForm,
+}: InlineCommentThreadProps) {
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+
+  return (
+    <div className="border-t border-border bg-[#161b22]">
+      {comments.map(({ comment, index }) => {
+        if (editingIndex === index) {
+          return (
+            <InlineCommentForm
+              key={index}
+              initialBody={comment.body}
+              initialType={comment.type}
+              onSave={(body, type) => {
+                onUpdate(index, body, type);
+                setEditingIndex(null);
+              }}
+              onCancel={() => setEditingIndex(null)}
+            />
+          );
+        }
+
+        return (
+          <div
+            key={index}
+            className="px-3 py-2 border-b border-border/50 group/comment"
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <span
+                className={`text-[10px] font-bold px-1.5 py-0.5 rounded border ${TYPE_STYLES[comment.type]}`}
+              >
+                {TYPE_LABELS[comment.type]}
+              </span>
+              <span className="text-text-secondary text-[10px] font-mono">
+                {file}:{line}
+              </span>
+              <div className="flex-1" />
+              <button
+                onClick={() => setEditingIndex(index)}
+                className="opacity-0 group-hover/comment:opacity-100 p-0.5 text-text-secondary hover:text-text-primary transition-all cursor-pointer"
+                title="Edit comment"
+              >
+                <Pencil className="w-3 h-3" />
+              </button>
+              <button
+                onClick={() => onDelete(index)}
+                className="opacity-0 group-hover/comment:opacity-100 p-0.5 text-text-secondary hover:text-red-400 transition-all cursor-pointer"
+                title="Delete comment"
+              >
+                <Trash2 className="w-3 h-3" />
+              </button>
+            </div>
+            <p className="text-text-primary text-sm whitespace-pre-wrap">
+              {comment.body}
+            </p>
+          </div>
+        );
+      })}
+
+      {isFormOpen && editingIndex === null && (
+        <InlineCommentForm
+          onSave={(body, type) => {
+            onAdd(body, type);
+            onCloseForm();
+          }}
+          onCancel={onCloseForm}
+        />
+      )}
+
+      {!isFormOpen && comments.length > 0 && editingIndex === null && (
+        <button
+          onClick={onOpenForm}
+          className="flex items-center gap-1 px-3 py-1.5 text-xs text-text-secondary hover:text-accent transition-colors cursor-pointer"
+        >
+          <Plus className="w-3 h-3" />
+          Add comment
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/InlineComment/index.ts
+++ b/packages/ui/src/components/InlineComment/index.ts
@@ -1,0 +1,2 @@
+export { InlineCommentForm } from "./InlineCommentForm";
+export { InlineCommentThread } from "./InlineCommentThread";

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -221,6 +221,56 @@
   color: #a5d6ff;
 }
 
+/* ─── Inline commenting ─── */
+
+/* Make gutters clickable */
+.diff-unified .diff-gutter,
+.diff-split .diff-gutter {
+  cursor: pointer;
+  position: relative;
+}
+
+/* Green "+" button on gutter hover */
+.diff-gutter-add-comment {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  background-color: #238636;
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 1;
+  position: absolute;
+  left: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+/* Blue dot for lines with existing comments */
+.diff-comment-indicator {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: #58a6ff;
+  position: absolute;
+  left: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+/* Widget row styling */
+.diff-widget {
+  background-color: #161b22;
+}
+
+.diff-widget-content {
+  padding: 0;
+}
+
 /* Scrollbar styling for dark theme */
 ::-webkit-scrollbar {
   width: 8px;

--- a/ui-dist/index.html
+++ b/ui-dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DiffPrism</title>
-    <script type="module" crossorigin src="/assets/index-D_t2y2BP.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CwE0rW9A.css">
+    <script type="module" crossorigin src="/assets/index-BtEI7qe5.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-Dlg-Xehq.css">
   </head>
   <body style="background-color: #0d1117; margin: 0;">
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- **Inline commenting:** Click any line gutter to open a comment form below it. Comments support four types (must_fix, suggestion, question, nitpick) with colored badges. Edit, delete, and add multiple comments per line. All comments included in `ReviewResult` payload on submit.
- **File-level review status:** Cycle files through unreviewed/reviewed/approved/needs_changes. Status badges shown in file browser sidebar and included in `ReviewResult`.
- **Comment count badge** displayed in the action bar when comments exist.

## Release Notes
- Add inline line-level commenting to the diff viewer using react-diff-view's `gutterEvents`, `renderGutter`, and `widgets` primitives
- Add file-level review status tracking with visual indicators in the file browser
- Comments and file statuses are now included in the `ReviewResult` submitted to the agent

Closes #18, Closes #19

## Test plan
- [x] `pnpm test` — all 78 tests pass
- [x] `pnpm run build` — full build succeeds
- [ ] Manual: hover over lines → green "+" button appears in gutter
- [ ] Manual: click a line → comment form appears below it
- [ ] Manual: save comment → renders inline with type badge, blue dot in gutter
- [ ] Manual: edit/delete comments work correctly
- [ ] Manual: submit review → `ReviewResult.comments` contains all inline comments
- [ ] Manual: cycle file status in sidebar → badge updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)