### PR TITLE
minor: Display current branch name in review UI

### DIFF
--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -5,7 +5,7 @@ import getPort from "get-port";
 import open from "open";
 import { fileURLToPath } from "node:url";
 
-import { getDiff } from "@diffprism/git";
+import { getDiff, getCurrentBranch } from "@diffprism/git";
 import { analyze } from "@diffprism/analysis";
 
 import type { ReviewResult, ReviewOptions, ReviewInitPayload } from "./types.js";
@@ -133,6 +133,7 @@ export async function startReview(
 
   // 1. Get the diff
   const { diffSet, rawDiff } = getDiff(diffRef, { cwd });
+  const currentBranch = getCurrentBranch({ cwd });
 
   // Handle empty diff
   if (diffSet.files.length === 0) {
@@ -191,7 +192,7 @@ export async function startReview(
       diffSet,
       rawDiff,
       briefing,
-      metadata: { title, description, reasoning },
+      metadata: { title, description, reasoning, currentBranch },
     };
 
     bridge.sendInit(initPayload);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -136,6 +136,7 @@ export interface ReviewMetadata {
   title?: string;
   description?: string;
   reasoning?: string;
+  currentBranch?: string;
 }
 
 export type ServerMessage = {

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -2,7 +2,7 @@ import type { DiffSet } from "@diffprism/core";
 import { getGitDiff } from "./local.js";
 import { parseDiff } from "./parser.js";
 
-export { getGitDiff } from "./local.js";
+export { getGitDiff, getCurrentBranch } from "./local.js";
 export { parseDiff } from "./parser.js";
 
 /**

--- a/packages/git/src/local.ts
+++ b/packages/git/src/local.ts
@@ -73,6 +73,25 @@ export function getGitDiff(
 }
 
 /**
+ * Get the current git branch name.
+ *
+ * @param options.cwd - Working directory for the git command.  Defaults to process.cwd().
+ * @returns The current branch name, or "unknown" on failure.
+ */
+export function getCurrentBranch(options?: { cwd?: string }): string {
+  const cwd = options?.cwd ?? process.cwd();
+  try {
+    return execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
  * Find untracked files and generate unified diff output for each one,
  * so they appear as "added" files in the parsed DiffSet.
  */

--- a/packages/ui/src/components/BriefingBar/BriefingBar.tsx
+++ b/packages/ui/src/components/BriefingBar/BriefingBar.tsx
@@ -9,12 +9,13 @@ import {
   Gauge,
   ShieldAlert,
   Search,
+  GitBranch,
 } from "lucide-react";
 import { useReviewStore } from "../../store/review";
 
 export function BriefingBar() {
   const [expanded, setExpanded] = useState(false);
-  const { briefing } = useReviewStore();
+  const { briefing, metadata } = useReviewStore();
 
   if (!briefing) return null;
   
@@ -31,13 +32,20 @@ export function BriefingBar() {
       {/* Collapsed row */}
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full px-4 py-2.5 flex items-center gap-3 cursor-pointer hover:bg-white/5 transition-colors"
+        className="w-full px-4 py-2.5 flex items-center gap-3 cursor-pointer hover:bg-text-primary/5 transition-colors"
       >
         <span className="text-text-primary text-sm flex-1 text-left truncate">
           {briefing.summary}
         </span>
 
         <div className="flex items-center gap-2 flex-shrink-0">
+          {metadata?.currentBranch && (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-gray-600/20 text-gray-400 border border-gray-500/30 font-mono">
+              <GitBranch className="w-3 h-3" />
+              {metadata.currentBranch}
+            </span>
+          )}
+
           {moduleCount > 0 && (
             <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-blue-600/20 text-blue-400 border border-blue-500/30">
               <FolderOpen className="w-3 h-3" />

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -137,6 +137,7 @@ export interface ReviewMetadata {
   title?: string;
   description?: string;
   reasoning?: string;
+  currentBranch?: string;
 }
 
 export type ServerMessage = {


### PR DESCRIPTION
## What changed
- Added `getCurrentBranch()` to `@diffprism/git` — runs `git rev-parse --abbrev-ref HEAD`, returns `"unknown"` on failure
- Added `currentBranch?: string` to `ReviewMetadata` (core + UI types)
- Pipeline populates `currentBranch` in metadata sent via WebSocket
- BriefingBar shows a neutral gray badge with `GitBranch` icon before existing analysis badges

## Why
Closes #36 — When working across multiple git worktrees, reviewers had no way to tell which branch a review was for.

## Testing
- `pnpm test` passes (78 tests)
- `pnpm run build` passes
- Verified branch badge renders in BriefingBar via CLI review