### PR TITLE
patch: Fix color readability for light mode

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -49,9 +49,9 @@ export default function App() {
     return (
       <div className="h-screen flex items-center justify-center bg-background">
         <div className="text-center">
-          <div className="w-16 h-16 rounded-full bg-green-600/20 border border-green-500/30 flex items-center justify-center mx-auto mb-4">
+          <div className="w-16 h-16 rounded-full bg-green-100 dark:bg-green-600/20 border border-green-300 dark:border-green-500/30 flex items-center justify-center mx-auto mb-4">
             <svg
-              className="w-8 h-8 text-green-400"
+              className="w-8 h-8 text-green-700 dark:text-green-400"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -82,9 +82,9 @@ export default function App() {
         <div className="text-center">
           {connectionStatus === "disconnected" ? (
             <>
-              <div className="w-12 h-12 rounded-full bg-red-600/20 border border-red-500/30 flex items-center justify-center mx-auto mb-4">
+              <div className="w-12 h-12 rounded-full bg-red-100 dark:bg-red-600/20 border border-red-300 dark:border-red-500/30 flex items-center justify-center mx-auto mb-4">
                 <svg
-                  className="w-6 h-6 text-red-400"
+                  className="w-6 h-6 text-red-700 dark:text-red-400"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"

--- a/packages/ui/src/components/ActionBar/ActionBar.tsx
+++ b/packages/ui/src/components/ActionBar/ActionBar.tsx
@@ -37,12 +37,12 @@ export function ActionBar({ onSubmit }: ActionBarProps) {
           {fileCount} file{fileCount !== 1 ? "s" : ""} changed
         </span>
         {totalAdditions > 0 && (
-          <span className="text-green-400 text-xs font-mono">
+          <span className="text-green-700 dark:text-green-400 text-xs font-mono">
             +{totalAdditions}
           </span>
         )}
         {totalDeletions > 0 && (
-          <span className="text-red-400 text-xs font-mono">
+          <span className="text-red-700 dark:text-red-400 text-xs font-mono">
             -{totalDeletions}
           </span>
         )}
@@ -67,7 +67,7 @@ export function ActionBar({ onSubmit }: ActionBarProps) {
       <div className="flex items-center gap-3">
         <button
           onClick={() => handleSubmit("approved")}
-          className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-green-600/20 text-green-400 border border-green-500/30 hover:bg-green-600/30 hover:border-green-500/50 cursor-pointer"
+          className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-green-100 dark:bg-green-600/20 text-green-700 dark:text-green-400 border border-green-300 dark:border-green-500/30 hover:bg-green-200 dark:hover:bg-green-600/30 hover:border-green-400 dark:hover:border-green-500/50 cursor-pointer"
         >
           <Check className="w-4 h-4" />
           Approve
@@ -75,7 +75,7 @@ export function ActionBar({ onSubmit }: ActionBarProps) {
 
         <button
           onClick={() => handleSubmit("changes_requested")}
-          className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-red-600/20 text-red-400 border border-red-500/30 hover:bg-red-600/30 hover:border-red-500/50 cursor-pointer"
+          className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-red-100 dark:bg-red-600/20 text-red-700 dark:text-red-400 border border-red-300 dark:border-red-500/30 hover:bg-red-200 dark:hover:bg-red-600/30 hover:border-red-400 dark:hover:border-red-500/50 cursor-pointer"
         >
           <X className="w-4 h-4" />
           Request Changes
@@ -83,7 +83,7 @@ export function ActionBar({ onSubmit }: ActionBarProps) {
 
         <button
           onClick={() => handleSubmit("approved_with_comments")}
-          className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-blue-600/20 text-blue-400 border border-blue-500/30 hover:bg-blue-600/30 hover:border-blue-500/50 cursor-pointer"
+          className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-blue-100 dark:bg-blue-600/20 text-blue-700 dark:text-blue-400 border border-blue-300 dark:border-blue-500/30 hover:bg-blue-200 dark:hover:bg-blue-600/30 hover:border-blue-400 dark:hover:border-blue-500/50 cursor-pointer"
         >
           <MessageSquare className="w-4 h-4" />
           Approve with Comments

--- a/packages/ui/src/components/BriefingBar/BriefingBar.tsx
+++ b/packages/ui/src/components/BriefingBar/BriefingBar.tsx
@@ -42,35 +42,35 @@ export function BriefingBar() {
 
         <div className="flex items-center gap-2 flex-shrink-0">
           {securityFlags.length > 0 && (
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-red-600/20 text-red-400 border border-red-500/30 font-semibold">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-red-100 dark:bg-red-600/20 text-red-700 dark:text-red-400 border border-red-300 dark:border-red-500/30 font-semibold">
               <ShieldAlert className="w-3 h-3" />
               {securityFlags.length} security flag{securityFlags.length !== 1 ? "s" : ""}
             </span>
           )}
 
           {metadata?.currentBranch && (
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-gray-600/20 text-gray-400 border border-gray-500/30 font-mono">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-gray-100 dark:bg-gray-600/20 text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-500/30 font-mono">
               <GitBranch className="w-3 h-3" />
               {metadata.currentBranch}
             </span>
           )}
 
           {moduleCount > 0 && (
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-blue-600/20 text-blue-400 border border-blue-500/30">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-blue-100 dark:bg-blue-600/20 text-blue-700 dark:text-blue-400 border border-blue-300 dark:border-blue-500/30">
               <FolderOpen className="w-3 h-3" />
               {moduleCount} module{moduleCount !== 1 ? "s" : ""}
             </span>
           )}
 
           {hasBreaking && (
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-red-600/20 text-red-400 border border-red-500/30">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-red-100 dark:bg-red-600/20 text-red-700 dark:text-red-400 border border-red-300 dark:border-red-500/30">
               <AlertTriangle className="w-3 h-3" />
               breaking
             </span>
           )}
 
           {hasNewDeps && (
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-yellow-600/20 text-yellow-400 border border-yellow-500/30">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-yellow-100 dark:bg-yellow-600/20 text-yellow-700 dark:text-yellow-400 border border-yellow-300 dark:border-yellow-500/30">
               <Package className="w-3 h-3" />
               {impact.newDependencies.length} new dep
               {impact.newDependencies.length !== 1 ? "s" : ""}
@@ -78,21 +78,21 @@ export function BriefingBar() {
           )}
 
           {highComplexity.length > 0 && (
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-orange-600/20 text-orange-400 border border-orange-500/30">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-orange-100 dark:bg-orange-600/20 text-orange-700 dark:text-orange-400 border border-orange-300 dark:border-orange-500/30">
               <Gauge className="w-3 h-3" />
               {highComplexity.length} complex
             </span>
           )}
 
           {coverageGaps.length > 0 && (
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-yellow-600/20 text-yellow-400 border border-yellow-500/30">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-yellow-100 dark:bg-yellow-600/20 text-yellow-700 dark:text-yellow-400 border border-yellow-300 dark:border-yellow-500/30">
               <ShieldAlert className="w-3 h-3" />
               {coverageGaps.length} untested
             </span>
           )}
 
           {patternCount > 0 && (
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-purple-600/20 text-purple-400 border border-purple-500/30">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-purple-100 dark:bg-purple-600/20 text-purple-700 dark:text-purple-400 border border-purple-300 dark:border-purple-500/30">
               <Search className="w-3 h-3" />
               {patternCount} pattern{patternCount !== 1 ? "s" : ""}
             </span>
@@ -112,7 +112,7 @@ export function BriefingBar() {
           {/* Security Flags */}
           {securityFlags.length > 0 && (
             <div className="col-span-2">
-              <h4 className="text-red-400 text-xs font-medium uppercase tracking-wide mb-1 flex items-center gap-1.5">
+              <h4 className="text-red-700 dark:text-red-400 text-xs font-medium uppercase tracking-wide mb-1 flex items-center gap-1.5">
                 <ShieldAlert className="w-3.5 h-3.5" />
                 Security Flags
               </h4>
@@ -122,15 +122,15 @@ export function BriefingBar() {
                     <span
                       className={`inline-block px-1 py-0.5 rounded text-[10px] font-medium uppercase mr-1.5 ${
                         p.severity === "critical"
-                          ? "bg-red-600/20 text-red-400 border border-red-500/30"
-                          : "bg-yellow-600/20 text-yellow-400 border border-yellow-500/30"
+                          ? "bg-red-100 dark:bg-red-600/20 text-red-700 dark:text-red-400 border border-red-300 dark:border-red-500/30"
+                          : "bg-yellow-100 dark:bg-yellow-600/20 text-yellow-700 dark:text-yellow-400 border border-yellow-300 dark:border-yellow-500/30"
                       }`}
                     >
                       {p.pattern.replace("_", " ")}
                     </span>
                     <span
                       className={`text-[10px] font-medium uppercase mr-1.5 ${
-                        p.severity === "critical" ? "text-red-400" : "text-yellow-400"
+                        p.severity === "critical" ? "text-red-700 dark:text-red-400" : "text-yellow-700 dark:text-yellow-400"
                       }`}
                     >
                       {p.severity}
@@ -190,13 +190,13 @@ export function BriefingBar() {
           {/* Breaking Changes */}
           {hasBreaking && (
             <div>
-              <h4 className="text-red-400 text-xs font-medium uppercase tracking-wide mb-1 flex items-center gap-1.5">
+              <h4 className="text-red-700 dark:text-red-400 text-xs font-medium uppercase tracking-wide mb-1 flex items-center gap-1.5">
                 <AlertTriangle className="w-3.5 h-3.5" />
                 Breaking Changes
               </h4>
               <ul className="space-y-0.5">
                 {impact.breakingChanges.map((bc) => (
-                  <li key={bc} className="text-red-400 text-xs">
+                  <li key={bc} className="text-red-700 dark:text-red-400 text-xs">
                     {bc}
                   </li>
                 ))}
@@ -207,7 +207,7 @@ export function BriefingBar() {
           {/* New Dependencies */}
           {hasNewDeps && (
             <div>
-              <h4 className="text-yellow-400 text-xs font-medium uppercase tracking-wide mb-1 flex items-center gap-1.5">
+              <h4 className="text-yellow-700 dark:text-yellow-400 text-xs font-medium uppercase tracking-wide mb-1 flex items-center gap-1.5">
                 <Package className="w-3.5 h-3.5" />
                 New Dependencies
               </h4>
@@ -227,7 +227,7 @@ export function BriefingBar() {
           {/* High Complexity */}
           {highComplexity.length > 0 && (
             <div>
-              <h4 className="text-orange-400 text-xs font-medium uppercase tracking-wide mb-1 flex items-center gap-1.5">
+              <h4 className="text-orange-700 dark:text-orange-400 text-xs font-medium uppercase tracking-wide mb-1 flex items-center gap-1.5">
                 <Gauge className="w-3.5 h-3.5" />
                 High Complexity
               </h4>
@@ -235,7 +235,7 @@ export function BriefingBar() {
                 {highComplexity.map((c) => (
                   <li key={c.path} className="text-text-primary text-xs">
                     <span className="font-mono">{c.path}</span>
-                    <span className="text-orange-400 ml-1">({c.score}/10)</span>
+                    <span className="text-orange-700 dark:text-orange-400 ml-1">({c.score}/10)</span>
                     {c.factors.length > 0 && (
                       <span className="text-text-secondary ml-1">
                         — {c.factors.join(", ")}
@@ -250,7 +250,7 @@ export function BriefingBar() {
           {/* Test Coverage Gaps */}
           {coverageGaps.length > 0 && (
             <div>
-              <h4 className="text-yellow-400 text-xs font-medium uppercase tracking-wide mb-1 flex items-center gap-1.5">
+              <h4 className="text-yellow-700 dark:text-yellow-400 text-xs font-medium uppercase tracking-wide mb-1 flex items-center gap-1.5">
                 <ShieldAlert className="w-3.5 h-3.5" />
                 Missing Test Changes
               </h4>
@@ -270,14 +270,14 @@ export function BriefingBar() {
           {/* Pattern Flags */}
           {nonSecurityPatterns.length > 0 && (
             <div>
-              <h4 className="text-purple-400 text-xs font-medium uppercase tracking-wide mb-1 flex items-center gap-1.5">
+              <h4 className="text-purple-700 dark:text-purple-400 text-xs font-medium uppercase tracking-wide mb-1 flex items-center gap-1.5">
                 <Search className="w-3.5 h-3.5" />
                 Pattern Flags
               </h4>
               <ul className="space-y-0.5">
                 {nonSecurityPatterns.map((p, i) => (
                   <li key={`${p.file}:${p.line}:${i}`} className="text-xs">
-                    <span className="inline-block px-1 py-0.5 rounded text-[10px] font-medium uppercase mr-1.5 bg-purple-600/20 text-purple-400 border border-purple-500/30">
+                    <span className="inline-block px-1 py-0.5 rounded text-[10px] font-medium uppercase mr-1.5 bg-purple-100 dark:bg-purple-600/20 text-purple-700 dark:text-purple-400 border border-purple-300 dark:border-purple-500/30">
                       {p.pattern}
                     </span>
                     <span className="font-mono text-text-secondary">
@@ -333,7 +333,7 @@ function VerificationBadge({
 
   return (
     <span
-      className={`text-xs ${value ? "text-green-400" : "text-red-400"}`}
+      className={`text-xs ${value ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}`}
     >
       {label}: <span className="font-mono">{value ? "pass" : "fail"}</span>
     </span>

--- a/packages/ui/src/components/DiffViewer/DiffViewer.tsx
+++ b/packages/ui/src/components/DiffViewer/DiffViewer.tsx
@@ -449,12 +449,12 @@ function FileHeader({
       </span>
       <div className="flex items-center gap-2 ml-auto flex-shrink-0">
         {additions !== undefined && additions > 0 && (
-          <span className="text-green-400 text-xs font-mono">
+          <span className="text-green-700 dark:text-green-400 text-xs font-mono">
             +{additions}
           </span>
         )}
         {deletions !== undefined && deletions > 0 && (
-          <span className="text-red-400 text-xs font-mono">
+          <span className="text-red-700 dark:text-red-400 text-xs font-mono">
             -{deletions}
           </span>
         )}

--- a/packages/ui/src/components/FileBrowser/FileBrowser.tsx
+++ b/packages/ui/src/components/FileBrowser/FileBrowser.tsx
@@ -16,22 +16,22 @@ function getStatusBadge(status: DiffFile["status"]) {
     case "added":
       return {
         label: "A",
-        className: "bg-green-600/20 text-green-400 border-green-500/30",
+        className: "bg-green-100 dark:bg-green-600/20 text-green-700 dark:text-green-400 border-green-300 dark:border-green-500/30",
       };
     case "modified":
       return {
         label: "M",
-        className: "bg-yellow-600/20 text-yellow-400 border-yellow-500/30",
+        className: "bg-yellow-100 dark:bg-yellow-600/20 text-yellow-700 dark:text-yellow-400 border-yellow-300 dark:border-yellow-500/30",
       };
     case "deleted":
       return {
         label: "D",
-        className: "bg-red-600/20 text-red-400 border-red-500/30",
+        className: "bg-red-100 dark:bg-red-600/20 text-red-700 dark:text-red-400 border-red-300 dark:border-red-500/30",
       };
     case "renamed":
       return {
         label: "R",
-        className: "bg-purple-600/20 text-purple-400 border-purple-500/30",
+        className: "bg-purple-100 dark:bg-purple-600/20 text-purple-700 dark:text-purple-400 border-purple-300 dark:border-purple-500/30",
       };
   }
 }
@@ -40,13 +40,13 @@ function getStatusIcon(status: DiffFile["status"]) {
   const iconClass = "w-4 h-4 flex-shrink-0";
   switch (status) {
     case "added":
-      return <FilePlus className={`${iconClass} text-green-400`} />;
+      return <FilePlus className={`${iconClass} text-green-700 dark:text-green-400`} />;
     case "deleted":
-      return <FileMinus className={`${iconClass} text-red-400`} />;
+      return <FileMinus className={`${iconClass} text-red-700 dark:text-red-400`} />;
     case "modified":
-      return <FilePenLine className={`${iconClass} text-yellow-400`} />;
+      return <FilePenLine className={`${iconClass} text-yellow-700 dark:text-yellow-400`} />;
     case "renamed":
-      return <FileCode className={`${iconClass} text-purple-400`} />;
+      return <FileCode className={`${iconClass} text-purple-700 dark:text-purple-400`} />;
   }
 }
 
@@ -56,11 +56,11 @@ function getReviewStatusIcon(status: FileReviewStatus) {
     case "unreviewed":
       return null;
     case "reviewed":
-      return <Eye className={`${iconClass} text-blue-400`} />;
+      return <Eye className={`${iconClass} text-blue-700 dark:text-blue-400`} />;
     case "approved":
-      return <CheckCircle className={`${iconClass} text-green-400`} />;
+      return <CheckCircle className={`${iconClass} text-green-700 dark:text-green-400`} />;
     case "needs_changes":
-      return <AlertCircle className={`${iconClass} text-yellow-400`} />;
+      return <AlertCircle className={`${iconClass} text-yellow-700 dark:text-yellow-400`} />;
   }
 }
 
@@ -149,12 +149,12 @@ export function FileBrowser() {
             {diffSet.files.length} file{diffSet.files.length !== 1 ? "s" : ""}
           </span>
           {totalAdditions > 0 && (
-            <span className="text-green-400 text-xs font-mono">
+            <span className="text-green-700 dark:text-green-400 text-xs font-mono">
               +{totalAdditions}
             </span>
           )}
           {totalDeletions > 0 && (
-            <span className="text-red-400 text-xs font-mono">
+            <span className="text-red-700 dark:text-red-400 text-xs font-mono">
               -{totalDeletions}
             </span>
           )}
@@ -193,7 +193,7 @@ export function FileBrowser() {
                   {basename(file.path)}
                 </div>
                 {dir && (
-                  <div className="text-xs text-text-secondary/60 truncate">
+                  <div className="text-xs text-text-secondary/80 dark:text-text-secondary/60 truncate">
                     {dir}
                   </div>
                 )}
@@ -227,12 +227,12 @@ export function FileBrowser() {
                   );
                 })()}
                 {file.additions > 0 && (
-                  <span className="text-green-400 text-xs font-mono">
+                  <span className="text-green-700 dark:text-green-400 text-xs font-mono">
                     +{file.additions}
                   </span>
                 )}
                 {file.deletions > 0 && (
-                  <span className="text-red-400 text-xs font-mono">
+                  <span className="text-red-700 dark:text-red-400 text-xs font-mono">
                     -{file.deletions}
                   </span>
                 )}

--- a/packages/ui/src/components/InlineComment/InlineCommentThread.tsx
+++ b/packages/ui/src/components/InlineComment/InlineCommentThread.tsx
@@ -4,10 +4,10 @@ import type { ReviewComment } from "../../types";
 import { InlineCommentForm } from "./InlineCommentForm";
 
 const TYPE_STYLES: Record<ReviewComment["type"], string> = {
-  must_fix: "bg-red-600/20 text-red-400 border-red-500/30",
-  suggestion: "bg-yellow-600/20 text-yellow-400 border-yellow-500/30",
-  question: "bg-blue-600/20 text-blue-400 border-blue-500/30",
-  nitpick: "bg-gray-600/20 text-gray-400 border-gray-500/30",
+  must_fix: "bg-red-100 dark:bg-red-600/20 text-red-700 dark:text-red-400 border-red-300 dark:border-red-500/30",
+  suggestion: "bg-yellow-100 dark:bg-yellow-600/20 text-yellow-700 dark:text-yellow-400 border-yellow-300 dark:border-yellow-500/30",
+  question: "bg-blue-100 dark:bg-blue-600/20 text-blue-700 dark:text-blue-400 border-blue-300 dark:border-blue-500/30",
+  nitpick: "bg-gray-100 dark:bg-gray-600/20 text-gray-600 dark:text-gray-400 border-gray-300 dark:border-gray-500/30",
 };
 
 const TYPE_LABELS: Record<ReviewComment["type"], string> = {
@@ -84,7 +84,7 @@ export function InlineCommentThread({
               </button>
               <button
                 onClick={() => onDelete(index)}
-                className="opacity-0 group-hover/comment:opacity-100 p-0.5 text-text-secondary hover:text-red-400 transition-all cursor-pointer"
+                className="opacity-0 group-hover/comment:opacity-100 p-0.5 text-text-secondary hover:text-red-700 dark:hover:text-red-400 transition-all cursor-pointer"
                 title="Delete comment"
               >
                 <Trash2 className="w-3 h-3" />

--- a/packages/ui/src/components/ReasoningPanel/ReasoningPanel.tsx
+++ b/packages/ui/src/components/ReasoningPanel/ReasoningPanel.tsx
@@ -14,7 +14,7 @@ export function ReasoningPanel() {
         onClick={() => setExpanded(!expanded)}
         className="w-full px-4 py-2.5 flex items-center gap-3 cursor-pointer hover:bg-text-primary/5 transition-colors"
       >
-        <Brain className="w-4 h-4 text-purple-400 flex-shrink-0" />
+        <Brain className="w-4 h-4 text-purple-700 dark:text-purple-400 flex-shrink-0" />
         <span className="text-text-primary text-sm flex-1 text-left truncate">
           Agent Reasoning
         </span>

--- a/ui-dist/index.html
+++ b/ui-dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DiffPrism</title>
-    <script type="module" crossorigin src="/assets/index-Sr2OzdyW.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BdoPehJH.css">
+    <script type="module" crossorigin src="/assets/index-CpWq5K0r.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-GiCSAMgl.css">
   </head>
   <body style="background-color: var(--color-background); margin: 0;">
     <div id="root"></div>


### PR DESCRIPTION
## What changed
- Added `dark:` variants to all hardcoded Tailwind color classes across 7 UI components
- **Text colors:** `*-700` in light mode (WCAG AA compliant, ~5:1 contrast ratio) / `*-400` in dark mode (unchanged)
- **Badge backgrounds:** `*-100` in light / `*-600/20` in dark (unchanged)
- **Badge borders:** `*-300` in light / `*-500/30` in dark (unchanged)
- **File path directories:** Bumped opacity from 60% to 80% in light mode for readability

### Files updated
- `App.tsx` — success/error state icons
- `ActionBar.tsx` — approve/reject/comment buttons + stats
- `BriefingBar.tsx` — all briefing badges + expanded section headers
- `DiffViewer.tsx` — file header addition/deletion stats
- `FileBrowser.tsx` — file status badges, icons, stats, directory paths
- `InlineCommentThread.tsx` — comment type badges
- `ReasoningPanel.tsx` — brain icon

## Why
Closes #50 — All UI components used hardcoded `*-400` Tailwind text colors which have terrible contrast on light backgrounds (all failing WCAG AA 4.5:1 minimum). Since v0.9.0 added light/dark mode toggle, these needed `dark:` prefix variants.

## Testing
- `pnpm test` passes (134/134 tests)
- `pnpm run build` passes
- Visually verified dark mode colors unchanged
- Light mode text now uses darker variants for proper contrast

## Release notes
Fix light mode color readability across all UI components. Badges, icons, stat counters, and file paths now use darker color variants in light mode while preserving the existing dark mode appearance.