### PR TITLE
patch: Fix notify-stop hook using stale npx cache

### DIFF
--- a/cli/src/__tests__/setup.test.ts
+++ b/cli/src/__tests__/setup.test.ts
@@ -186,7 +186,7 @@ describe("setup command", () => {
       });
       expect(hookWrite).toBeDefined();
       const hookData = JSON.parse(hookWrite![1] as string);
-      expect(hookData.hooks.Stop[0].hooks[0].command).toBe("npx diffprism notify-stop");
+      expect(hookData.hooks.Stop[0].hooks[0].command).toBe("npx diffprism@latest notify-stop");
     });
 
     it("preserves existing permissions", async () => {
@@ -244,7 +244,7 @@ describe("setup command", () => {
             hooks: {
               Stop: [{
                 matcher: "",
-                hooks: [{ type: "command", command: "npx diffprism notify-stop" }],
+                hooks: [{ type: "command", command: "npx diffprism@latest notify-stop" }],
               }],
             },
           });

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -144,7 +144,7 @@ function setupStopHook(
   const hooks = (existing.hooks ?? {}) as Record<string, unknown>;
   const stopHooks = hooks.Stop as Array<Record<string, unknown>> | undefined;
 
-  const hookCommand = "npx diffprism notify-stop";
+  const hookCommand = "npx diffprism@latest notify-stop";
 
   // Check if hook already exists
   if (stopHooks && !force) {


### PR DESCRIPTION
## Summary
- Stop hook command changed from `npx diffprism notify-stop` to `npx diffprism@latest notify-stop`
- Prevents npx from resolving a cached older version that doesn't have the `notify-stop` command

## Why
After publishing v0.13.0 with watch mode, the Stop hook failed because `npx diffprism` resolved the cached v0.12.2 which didn't have `notify-stop`. Pinning to `@latest` ensures the hook always uses the current published version.

## Testing
- `pnpm test` passes
- Updated test assertions to match new command string

🤖 Generated with [Claude Code](https://claude.com/claude-code)