### PR TITLE
patch: Fix watch mode resetting UI after review submit

### DIFF
--- a/packages/core/src/watch-bridge.ts
+++ b/packages/core/src/watch-bridge.ts
@@ -12,6 +12,7 @@ import type {
 export interface WatchBridge {
   port: number;
   sendInit: (payload: ReviewInitPayload) => void;
+  storeInitPayload: (payload: ReviewInitPayload) => void;
   sendDiffUpdate: (payload: DiffUpdatePayload) => void;
   sendContextUpdate: (payload: ContextUpdatePayload) => void;
   onSubmit: (callback: (result: ReviewResult) => void) => void;
@@ -145,6 +146,10 @@ export function createWatchBridge(
           } else {
             pendingInit = payload;
           }
+        },
+
+        storeInitPayload(payload: ReviewInitPayload) {
+          initPayload = payload;
         },
 
         sendDiffUpdate(payload: DiffUpdatePayload) {

--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -190,8 +190,8 @@ export async function startWatch(options: WatchOptions): Promise<WatchHandle> {
         lastDiffHash = newHash;
         lastDiffSet = newDiffSet;
 
-        // Also update the stored init payload for reconnects
-        bridge.sendInit({
+        // Update stored init payload for reconnects (don't send to connected client)
+        bridge.storeInitPayload({
           reviewId,
           diffSet: newDiffSet,
           rawDiff: newRawDiff,


### PR DESCRIPTION
## Summary
- Poll loop now uses `storeInitPayload()` instead of `sendInit()` to update the stored init payload for reconnects
- Connected clients only receive `diff:update` messages during poll updates, not `review:init`

## Why
After submitting a review in watch mode, the UI briefly showed "Watching for changes..." then immediately snapped back to showing the same diff. The poll loop was calling `bridge.sendInit()` which sent `review:init` to the connected client, triggering `initReview` in the store and resetting `watchSubmitted: false`.

## Testing
- `pnpm test` passes
- `pnpm run build` passes
- Watch mode: submit review → stays on "Watching for changes..." until files actually change

🤖 Generated with [Claude Code](https://claude.com/claude-code)