### PR TITLE
patch: Keep review visible in watch mode after submit

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -6,7 +6,7 @@ import type { ReviewResult } from "./types";
 
 export default function App() {
   const { sendResult, connectionStatus } = useWebSocket();
-  const { diffSet, metadata, theme, isWatchMode, watchSubmitted, setWatchSubmitted } =
+  const { diffSet, metadata, theme, isWatchMode, watchSubmitted, hasUnreviewedChanges, setWatchSubmitted } =
     useReviewStore();
   const [submitted, setSubmitted] = useState(false);
   const [countdown, setCountdown] = useState(3);
@@ -21,18 +21,9 @@ export default function App() {
     }
   }, [theme]);
 
-  // When watch mode receives a new diff after submit, transition back to review
-  useEffect(() => {
-    if (isWatchMode && submitted && !watchSubmitted) {
-      setSubmitted(false);
-      setCountdown(3);
-    }
-  }, [isWatchMode, submitted, watchSubmitted]);
-
   function handleSubmit(result: ReviewResult) {
     sendResult(result);
     if (isWatchMode) {
-      setSubmitted(true);
       setWatchSubmitted(true);
     } else {
       setSubmitted(true);
@@ -58,43 +49,6 @@ export default function App() {
 
     return () => clearTimeout(timer);
   }, [submitted, countdown, closeWindow, isWatchMode]);
-
-  // Watch mode: submitted state — waiting for changes
-  if (submitted && isWatchMode) {
-    return (
-      <div className="h-screen flex items-center justify-center bg-background">
-        <div className="text-center">
-          <div className="w-16 h-16 rounded-full bg-green-100 dark:bg-green-600/20 border border-green-300 dark:border-green-500/30 flex items-center justify-center mx-auto mb-4">
-            <svg
-              className="w-8 h-8 text-green-700 dark:text-green-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-          </div>
-          <h1 className="text-text-primary text-xl font-semibold mb-2">
-            Review Submitted
-          </h1>
-          <div className="flex items-center justify-center gap-2 mt-4">
-            <span className="relative flex h-3 w-3">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
-              <span className="relative inline-flex rounded-full h-3 w-3 bg-green-500" />
-            </span>
-            <p className="text-text-secondary text-sm">
-              Watching for changes...
-            </p>
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   // Non-watch mode: submitted confirmation with countdown
   if (submitted) {
@@ -188,7 +142,12 @@ export default function App() {
           <span className="text-xs text-text-secondary">Watching</span>
         </div>
       )}
-      <ReviewView onSubmit={handleSubmit} />
+      <ReviewView
+        onSubmit={handleSubmit}
+        isWatchMode={isWatchMode}
+        watchSubmitted={watchSubmitted}
+        hasUnreviewedChanges={hasUnreviewedChanges}
+      />
     </div>
   );
 }

--- a/packages/ui/src/__tests__/store.test.ts
+++ b/packages/ui/src/__tests__/store.test.ts
@@ -66,6 +66,7 @@ describe("review store", () => {
       theme: "dark",
       isWatchMode: false,
       watchSubmitted: false,
+      hasUnreviewedChanges: true,
     });
   });
 

--- a/packages/ui/src/components/ActionBar/ActionBar.tsx
+++ b/packages/ui/src/components/ActionBar/ActionBar.tsx
@@ -5,9 +5,12 @@ import { useReviewStore } from "../../store/review";
 
 interface ActionBarProps {
   onSubmit: (result: ReviewResult) => void;
+  isWatchMode?: boolean;
+  watchSubmitted?: boolean;
+  hasUnreviewedChanges?: boolean;
 }
 
-export function ActionBar({ onSubmit }: ActionBarProps) {
+export function ActionBar({ onSubmit, isWatchMode, watchSubmitted, hasUnreviewedChanges }: ActionBarProps) {
   const [summary, setSummary] = useState("");
   const { diffSet, fileStatuses, comments } = useReviewStore();
 
@@ -29,8 +32,38 @@ export function ActionBar({ onSubmit }: ActionBarProps) {
     });
   }
 
+  // Watch mode: submitted with no new changes — compact bar
+  if (isWatchMode && watchSubmitted && !hasUnreviewedChanges) {
+    return (
+      <div className="bg-surface border-t border-border px-4 py-3 flex-shrink-0">
+        <div className="flex items-center gap-3">
+          <Check className="w-4 h-4 text-green-700 dark:text-green-400" />
+          <span className="text-sm text-green-700 dark:text-green-400 font-medium">
+            Review submitted
+          </span>
+          <span className="relative flex h-2 w-2 ml-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+          </span>
+          <span className="text-xs text-text-secondary">Watching for changes...</span>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="bg-surface border-t border-border px-4 py-3 flex-shrink-0">
+      {/* New changes banner in watch mode */}
+      {isWatchMode && watchSubmitted && hasUnreviewedChanges && (
+        <div className="flex items-center gap-2 mb-3 text-xs text-accent">
+          <span className="relative flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+          </span>
+          New changes detected
+        </div>
+      )}
+
       {/* Stats row */}
       <div className="flex items-center gap-4 mb-3">
         <span className="text-text-secondary text-xs">

--- a/packages/ui/src/components/ReviewView.tsx
+++ b/packages/ui/src/components/ReviewView.tsx
@@ -7,9 +7,12 @@ import type { ReviewResult } from "../types";
 
 interface ReviewViewProps {
   onSubmit: (result: ReviewResult) => void;
+  isWatchMode?: boolean;
+  watchSubmitted?: boolean;
+  hasUnreviewedChanges?: boolean;
 }
 
-export function ReviewView({ onSubmit }: ReviewViewProps) {
+export function ReviewView({ onSubmit, isWatchMode, watchSubmitted, hasUnreviewedChanges }: ReviewViewProps) {
   return (
     <div className="h-screen flex flex-col bg-background">
       <BriefingBar />
@@ -25,7 +28,12 @@ export function ReviewView({ onSubmit }: ReviewViewProps) {
       </div>
 
       {/* Bottom — Action Bar */}
-      <ActionBar onSubmit={onSubmit} />
+      <ActionBar
+        onSubmit={onSubmit}
+        isWatchMode={isWatchMode}
+        watchSubmitted={watchSubmitted}
+        hasUnreviewedChanges={hasUnreviewedChanges}
+      />
     </div>
   );
 }

--- a/packages/ui/src/store/review.ts
+++ b/packages/ui/src/store/review.ts
@@ -34,6 +34,7 @@ export interface ReviewState {
   theme: Theme;
   isWatchMode: boolean;
   watchSubmitted: boolean;
+  hasUnreviewedChanges: boolean;
 
   // Actions
   initReview: (payload: ReviewInitPayload) => void;
@@ -67,6 +68,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   theme: (localStorage.getItem("diffprism-theme") as Theme) ?? "dark",
   isWatchMode: false,
   watchSubmitted: false,
+  hasUnreviewedChanges: true,
 
   initReview: (payload: ReviewInitPayload) => {
     const firstFile =
@@ -91,6 +93,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       activeCommentKey: null,
       isWatchMode: payload.watchMode ?? false,
       watchSubmitted: false,
+      hasUnreviewedChanges: true,
     });
   },
 
@@ -179,7 +182,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       briefing: payload.briefing,
       fileStatuses,
       selectedFile,
-      watchSubmitted: false,
+      hasUnreviewedChanges: true,
     });
   },
 
@@ -198,6 +201,9 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   },
 
   setWatchSubmitted: (submitted: boolean) => {
-    set({ watchSubmitted: submitted });
+    set({
+      watchSubmitted: submitted,
+      ...(submitted && { hasUnreviewedChanges: false }),
+    });
   },
 }));


### PR DESCRIPTION
## Summary
- Remove fullscreen "Watching for changes..." splash screen that replaced the entire review UI after submitting in watch mode
- Keep the diff visible so users can continue browsing code after submitting
- Move watch status into the ActionBar: compact "Review submitted + watching" indicator when no new changes, full ActionBar with "New changes detected" banner when changes arrive
- Fix the jarring reset loop caused by `diff:update` (from `.diffprism/last-review.json` writes) resetting `watchSubmitted` via `updateDiff`

## Why
Closes the UX issues with watch mode submit: the fullscreen splash hid the code review, and any `diff:update` event would snap back to the diff view causing a loop. Adding `hasUnreviewedChanges` to the store decouples "submitted" state from "new changes arrived".

## Testing
- `pnpm test` — all UI tests pass (18/18)
- `pnpm run build` — builds cleanly
- Manual: `diffprism watch --dev --staged` → submit → ActionBar shows compact "submitted + watching", diff stays visible
- Stage a file change → ActionBar shows "New changes detected" + full buttons reappear
- Non-watch mode: `diffprism review --staged` → fullscreen submitted + countdown still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)