### PR TITLE
minor: Add multi-session UI with session list and switching

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -154,12 +154,12 @@ export type ServerMessage =
   | { type: "review:init"; payload: ReviewInitPayload }
   | { type: "diff:update"; payload: DiffUpdatePayload }
   | { type: "context:update"; payload: ContextUpdatePayload }
+  | { type: "session:list"; payload: SessionSummary[] }
   | { type: "session:added"; payload: SessionSummary };
 
-export type ClientMessage = {
-  type: "review:submit";
-  payload: ReviewResult;
-};
+export type ClientMessage =
+  | { type: "review:submit"; payload: ReviewResult }
+  | { type: "session:select"; payload: { sessionId: string } };
 
 // ─── Pipeline Options ───
 

--- a/packages/ui/src/components/SessionList/SessionList.tsx
+++ b/packages/ui/src/components/SessionList/SessionList.tsx
@@ -1,0 +1,135 @@
+import { GitBranch, FileCode, Clock } from "lucide-react";
+import type { SessionSummary } from "../../types";
+
+interface SessionListProps {
+  sessions: SessionSummary[];
+  activeSessionId: string | null;
+  onSelect: (sessionId: string) => void;
+}
+
+function formatTime(timestamp: number): string {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function getProjectName(projectPath: string): string {
+  const parts = projectPath.split("/");
+  return parts[parts.length - 1] || projectPath;
+}
+
+function statusBadge(status: SessionSummary["status"]) {
+  switch (status) {
+    case "pending":
+      return (
+        <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-yellow-600/20 text-yellow-400 border border-yellow-500/30">
+          Pending
+        </span>
+      );
+    case "in_review":
+      return (
+        <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-accent/20 text-accent border border-accent/30">
+          In Review
+        </span>
+      );
+    case "submitted":
+      return (
+        <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-green-600/20 text-green-400 border border-green-500/30">
+          Submitted
+        </span>
+      );
+  }
+}
+
+export function SessionList({ sessions, activeSessionId, onSelect }: SessionListProps) {
+  if (sessions.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full bg-background text-center px-8">
+        <div className="w-12 h-12 rounded-full bg-surface border border-border flex items-center justify-center mb-4">
+          <FileCode className="w-6 h-6 text-text-secondary" />
+        </div>
+        <h2 className="text-text-primary text-lg font-semibold mb-2">
+          No reviews yet
+        </h2>
+        <p className="text-text-secondary text-sm max-w-xs">
+          Reviews from Claude Code sessions will appear here when they use the{" "}
+          <code className="text-accent text-xs">open_review</code> tool.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-background">
+      {/* Header */}
+      <div className="px-6 py-4 border-b border-border">
+        <h2 className="text-text-primary text-sm font-semibold">
+          Review Sessions
+        </h2>
+        <span className="text-text-secondary text-xs">
+          {sessions.length} session{sessions.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Session cards */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-2">
+        {sessions.map((session) => {
+          const isActive = session.id === activeSessionId;
+
+          return (
+            <button
+              key={session.id}
+              onClick={() => onSelect(session.id)}
+              className={`w-full text-left px-4 py-3 rounded-lg border transition-colors ${
+                isActive
+                  ? "bg-accent/10 border-accent/40"
+                  : "bg-surface border-border hover:border-text-secondary/30"
+              }`}
+            >
+              {/* Title + status */}
+              <div className="flex items-center justify-between mb-1.5">
+                <span className="text-text-primary text-sm font-medium truncate mr-2">
+                  {session.title || getProjectName(session.projectPath)}
+                </span>
+                {statusBadge(session.status)}
+              </div>
+
+              {/* Branch + project */}
+              <div className="flex items-center gap-3 mb-1.5">
+                {session.branch && (
+                  <span className="flex items-center gap-1 text-text-secondary text-xs">
+                    <GitBranch className="w-3 h-3" />
+                    {session.branch}
+                  </span>
+                )}
+                <span className="text-text-secondary text-xs truncate">
+                  {getProjectName(session.projectPath)}
+                </span>
+              </div>
+
+              {/* Stats */}
+              <div className="flex items-center gap-3">
+                <span className="text-text-secondary text-xs">
+                  {session.fileCount} file{session.fileCount !== 1 ? "s" : ""}
+                </span>
+                {session.additions > 0 && (
+                  <span className="text-green-400 text-xs font-mono">
+                    +{session.additions}
+                  </span>
+                )}
+                {session.deletions > 0 && (
+                  <span className="text-red-400 text-xs font-mono">
+                    -{session.deletions}
+                  </span>
+                )}
+                <span className="flex items-center gap-1 text-text-secondary text-xs ml-auto">
+                  <Clock className="w-3 h-3" />
+                  {formatTime(session.createdAt)}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/SessionList/index.ts
+++ b/packages/ui/src/components/SessionList/index.ts
@@ -1,0 +1,1 @@
+export { SessionList } from "./SessionList";

--- a/packages/ui/src/store/review.ts
+++ b/packages/ui/src/store/review.ts
@@ -8,6 +8,7 @@ import type {
   ReviewMetadata,
   DiffUpdatePayload,
   ContextUpdatePayload,
+  SessionSummary,
 } from "../types";
 import { getFileKey } from "../lib/file-key";
 
@@ -37,6 +38,11 @@ export interface ReviewState {
   watchSubmitted: boolean;
   hasUnreviewedChanges: boolean;
 
+  // Server mode (multi-session)
+  isServerMode: boolean;
+  sessions: SessionSummary[];
+  activeSessionId: string | null;
+
   // Actions
   initReview: (payload: ReviewInitPayload) => void;
   selectFile: (path: string) => void;
@@ -52,6 +58,10 @@ export interface ReviewState {
   updateDiff: (payload: DiffUpdatePayload) => void;
   updateContext: (payload: ContextUpdatePayload) => void;
   setWatchSubmitted: (submitted: boolean) => void;
+  setServerMode: (isServerMode: boolean) => void;
+  setSessions: (sessions: SessionSummary[]) => void;
+  addSession: (session: SessionSummary) => void;
+  selectSession: (sessionId: string) => void;
 }
 
 export const useReviewStore = create<ReviewState>((set, get) => ({
@@ -70,6 +80,9 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   isWatchMode: false,
   watchSubmitted: false,
   hasUnreviewedChanges: true,
+  isServerMode: false,
+  sessions: [],
+  activeSessionId: null,
 
   initReview: (payload: ReviewInitPayload) => {
     const firstFile =
@@ -95,6 +108,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       isWatchMode: payload.watchMode ?? false,
       watchSubmitted: false,
       hasUnreviewedChanges: true,
+      activeSessionId: payload.reviewId,
     });
   },
 
@@ -207,5 +221,23 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       watchSubmitted: submitted,
       ...(submitted && { hasUnreviewedChanges: false }),
     });
+  },
+
+  setServerMode: (isServerMode: boolean) => {
+    set({ isServerMode });
+  },
+
+  setSessions: (sessions: SessionSummary[]) => {
+    set({ sessions });
+  },
+
+  addSession: (session: SessionSummary) => {
+    set((state) => ({
+      sessions: [...state.sessions, session],
+    }));
+  },
+
+  selectSession: (sessionId: string) => {
+    set({ activeSessionId: sessionId });
   },
 }));

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -183,9 +183,9 @@ export type ServerMessage =
   | { type: "review:init"; payload: ReviewInitPayload }
   | { type: "diff:update"; payload: DiffUpdatePayload }
   | { type: "context:update"; payload: ContextUpdatePayload }
+  | { type: "session:list"; payload: SessionSummary[] }
   | { type: "session:added"; payload: SessionSummary };
 
-export type ClientMessage = {
-  type: "review:submit";
-  payload: ReviewResult;
-};
+export type ClientMessage =
+  | { type: "review:submit"; payload: ReviewResult }
+  | { type: "session:select"; payload: { sessionId: string } };


### PR DESCRIPTION
## Summary
- Extended WS protocol with `session:list`, `session:added`, and `session:select` message types
- Updated global server to send session list on connect (no sessionId) and handle `session:select` for switching between reviews
- Added session state management to Zustand store (`isServerMode`, `sessions[]`, `activeSessionId`)
- Created `SessionList` component showing review sessions with status badges, branch info, file counts, and +/- stats
- Updated `App.tsx` to route to session list in server mode when no active review is loaded

## Why
Closes #90 — Step 3 of the Global DiffPrism Server plan (#86). Enables users to view and switch between multiple review sessions in a single browser tab when running `diffprism server`.

## Testing
- `pnpm test` passes (164 tests across all packages)
- `pnpm run build` passes
- 5 new store tests covering session management (setSessions, addSession, selectSession, setServerMode, initReview sets activeSessionId)

## Release Notes
Multi-session UI support for the global DiffPrism server. When running in server mode, the review UI now shows a list of all active review sessions with status badges, branch info, and change stats. Click any session to load its diff for review. Auto-selects when only one session exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)