### PR TITLE
minor: Add hotkey guide modal (#85)

### DIFF
--- a/packages/ui/src/components/DiffViewer/DiffViewer.tsx
+++ b/packages/ui/src/components/DiffViewer/DiffViewer.tsx
@@ -12,7 +12,7 @@ import {
 import type { ChangeData, HunkData, GutterOptions, ChangeEventArgs, EventMap } from "react-diff-view";
 import { refractor } from "refractor";
 import { useReviewStore } from "../../store/review";
-import { FileCode, Columns2, Rows2 } from "lucide-react";
+import { FileCode, Columns2, Rows2, HelpCircle } from "lucide-react";
 import { InlineCommentForm, InlineCommentThread } from "../InlineComment";
 import { ThemeToggle } from "../ThemeToggle";
 import { getFileKey, getDisplayPath } from "../../lib/file-key";
@@ -173,6 +173,7 @@ export function DiffViewer() {
     updateComment,
     deleteComment,
     setActiveCommentKey,
+    toggleHotkeyGuide,
   } = useReviewStore();
 
   const selectedDiffFile = useMemo(() => {
@@ -425,6 +426,7 @@ export function DiffViewer() {
         deletions={selectedDiffFile?.deletions}
         viewMode={viewMode}
         onViewModeChange={setViewMode}
+        onToggleHotkeyGuide={toggleHotkeyGuide}
       />
       <div className="flex-1 overflow-auto">
         <Diff
@@ -454,6 +456,7 @@ function FileHeader({
   deletions,
   viewMode,
   onViewModeChange,
+  onToggleHotkeyGuide,
 }: {
   path: string;
   stage?: "staged" | "unstaged";
@@ -461,6 +464,7 @@ function FileHeader({
   deletions?: number;
   viewMode?: "unified" | "split";
   onViewModeChange?: (mode: "unified" | "split") => void;
+  onToggleHotkeyGuide?: () => void;
 }) {
   return (
     <div className="flex items-center gap-3 px-4 py-2.5 bg-surface border-b border-border flex-shrink-0">
@@ -513,6 +517,15 @@ function FileHeader({
               <Columns2 className="w-3.5 h-3.5" />
             </button>
           </div>
+        )}
+        {onToggleHotkeyGuide && (
+          <button
+            onClick={onToggleHotkeyGuide}
+            className="p-1.5 rounded text-text-secondary hover:text-text-primary transition-colors cursor-pointer"
+            title="Keyboard shortcuts (?)"
+          >
+            <HelpCircle className="w-4 h-4" />
+          </button>
         )}
         <ThemeToggle />
       </div>

--- a/packages/ui/src/components/FileBrowser/FileBrowser.tsx
+++ b/packages/ui/src/components/FileBrowser/FileBrowser.tsx
@@ -79,7 +79,7 @@ function dirname(path: string): string {
 }
 
 export function FileBrowser() {
-  const { diffSet, selectedFile, selectFile, fileStatuses, cycleFileStatus } =
+  const { diffSet, selectedFile, selectFile, fileStatuses, cycleFileStatus, toggleHotkeyGuide } =
     useReviewStore();
 
   const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({});
@@ -151,12 +151,15 @@ export function FileBrowser() {
         if (selectedFile) {
           cycleFileStatus(selectedFile);
         }
+      } else if (e.key === "?") {
+        e.preventDefault();
+        toggleHotkeyGuide();
       }
     }
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [navigateFiles, selectedFile, cycleFileStatus]);
+  }, [navigateFiles, selectedFile, cycleFileStatus, toggleHotkeyGuide]);
 
   if (!diffSet) return null;
 

--- a/packages/ui/src/components/HotkeyGuide/HotkeyGuide.tsx
+++ b/packages/ui/src/components/HotkeyGuide/HotkeyGuide.tsx
@@ -1,0 +1,75 @@
+import { useEffect } from "react";
+import { useReviewStore } from "../../store/review";
+
+const isMac = navigator.platform.toUpperCase().includes("MAC");
+const modKey = isMac ? "\u2318" : "Ctrl";
+
+const shortcuts = [
+  { keys: ["j", "\u2193"], action: "Next file" },
+  { keys: ["k", "\u2191"], action: "Previous file" },
+  { keys: ["s"], action: "Cycle file status" },
+  { keys: [`${modKey} + Enter`], action: "Save comment" },
+  { keys: ["Esc"], action: "Cancel comment / Close guide" },
+  { keys: ["?"], action: "Toggle this guide" },
+];
+
+export function HotkeyGuide() {
+  const { showHotkeyGuide, toggleHotkeyGuide } = useReviewStore();
+
+  useEffect(() => {
+    if (!showHotkeyGuide) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" || e.key === "?") {
+        e.preventDefault();
+        e.stopPropagation();
+        toggleHotkeyGuide();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [showHotkeyGuide, toggleHotkeyGuide]);
+
+  if (!showHotkeyGuide) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={toggleHotkeyGuide}
+    >
+      <div
+        className="bg-surface border border-border rounded-lg shadow-xl p-6 max-w-sm w-full mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-text-primary text-sm font-semibold mb-4">
+          Keyboard Shortcuts
+        </h2>
+        <div className="space-y-2">
+          {shortcuts.map((shortcut) => (
+            <div
+              key={shortcut.action}
+              className="flex items-center justify-between gap-4"
+            >
+              <span className="text-text-secondary text-sm">
+                {shortcut.action}
+              </span>
+              <div className="flex items-center gap-1.5">
+                {shortcut.keys.map((key, i) => (
+                  <span key={key} className="flex items-center gap-1.5">
+                    {i > 0 && (
+                      <span className="text-text-secondary/50 text-xs">/</span>
+                    )}
+                    <kbd className="px-1.5 py-0.5 text-xs font-mono rounded border border-border bg-background text-text-primary">
+                      {key}
+                    </kbd>
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/HotkeyGuide/index.ts
+++ b/packages/ui/src/components/HotkeyGuide/index.ts
@@ -1,0 +1,1 @@
+export { HotkeyGuide } from "./HotkeyGuide";

--- a/packages/ui/src/components/ReviewView.tsx
+++ b/packages/ui/src/components/ReviewView.tsx
@@ -3,6 +3,7 @@ import { ReasoningPanel } from "./ReasoningPanel";
 import { FileBrowser } from "./FileBrowser";
 import { DiffViewer } from "./DiffViewer";
 import { ActionBar } from "./ActionBar";
+import { HotkeyGuide } from "./HotkeyGuide";
 import type { ReviewResult } from "../types";
 
 interface ReviewViewProps {
@@ -34,6 +35,7 @@ export function ReviewView({ onSubmit, isWatchMode, watchSubmitted, hasUnreviewe
         watchSubmitted={watchSubmitted}
         hasUnreviewedChanges={hasUnreviewedChanges}
       />
+      <HotkeyGuide />
     </div>
   );
 }

--- a/packages/ui/src/store/review.ts
+++ b/packages/ui/src/store/review.ts
@@ -39,11 +39,13 @@ export interface ReviewState {
   hasUnreviewedChanges: boolean;
 
   // Server mode (multi-session)
+  showHotkeyGuide: boolean;
   isServerMode: boolean;
   sessions: SessionSummary[];
   activeSessionId: string | null;
 
   // Actions
+  toggleHotkeyGuide: () => void;
   initReview: (payload: ReviewInitPayload) => void;
   selectFile: (path: string) => void;
   setConnectionStatus: (status: ReviewState["connectionStatus"]) => void;
@@ -80,6 +82,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   isWatchMode: false,
   watchSubmitted: false,
   hasUnreviewedChanges: true,
+  showHotkeyGuide: false,
   isServerMode: false,
   sessions: [],
   activeSessionId: null,
@@ -160,6 +163,10 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
 
   setActiveCommentKey: (key: string | null) => {
     set({ activeCommentKey: key });
+  },
+
+  toggleHotkeyGuide: () => {
+    set((state) => ({ showHotkeyGuide: !state.showHotkeyGuide }));
   },
 
   toggleTheme: () => {

--- a/ui-dist/index.html
+++ b/ui-dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>DiffPrism</title>
-    <script type="module" crossorigin src="/assets/index-CKJwY3F0.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-D39rVNSs.css">
+    <script type="module" crossorigin src="/assets/index-DHbSWJ8e.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BcuyMNeU.css">
   </head>
   <body style="background-color: var(--color-background); margin: 0;">
     <div id="root"></div>


### PR DESCRIPTION
## What changed

Added a keyboard shortcuts guide modal accessible via:
- Pressing `?` on the keyboard
- Clicking the `?` (HelpCircle) icon button in the DiffViewer file header

The guide displays all available shortcuts in a styled overlay:
| Key | Action |
|-----|--------|
| `j` / `↓` | Next file |
| `k` / `↑` | Previous file |
| `s` | Cycle file status |
| `⌘/Ctrl + Enter` | Save comment |
| `Esc` | Cancel comment / Close guide |
| `?` | Toggle this guide |

Dismissible via `?`, `Esc`, or clicking the backdrop.

## Why

Closes #85 — Users had no way to discover existing keyboard shortcuts. This adds a lightweight, discoverable hotkey guide without consuming any layout space.

## Testing

- `pnpm test` passes (198 tests)
- `pnpm run build` passes
- Manual: press `?` → guide appears → press `?` or `Esc` → closes
- Manual: click `?` icon in header → guide opens
- Shortcuts still work when guide is closed
- Guide does not open when typing in comment textarea

## Release notes

Adds a keyboard shortcuts guide modal. Press `?` or click the help icon in the file header to see all available hotkeys. Closes with `?`, `Esc`, or backdrop click.