### PR TITLE
patch: Gitignore all DiffPrism-generated files during setup

### DIFF
--- a/cli/src/commands/teardown.ts
+++ b/cli/src/commands/teardown.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { findGitRoot, readJsonFile, writeJsonFile, cleanDiffprismHooks } from "./setup.js";
+import { findGitRoot, readJsonFile, writeJsonFile, cleanDiffprismHooks, GITIGNORE_ENTRIES } from "./setup.js";
 
 interface TeardownFlags {
   global?: boolean;
@@ -157,7 +157,8 @@ function teardownGitignore(gitRoot: string): { action: "removed" | "skipped"; fi
 
   const content = fs.readFileSync(filePath, "utf-8");
   const lines = content.split("\n");
-  const filtered = lines.filter((l) => l.trim() !== ".diffprism");
+  const entrySet = new Set(GITIGNORE_ENTRIES);
+  const filtered = lines.filter((l) => !entrySet.has(l.trim()));
 
   if (filtered.length === lines.length) {
     return { action: "skipped", filePath };


### PR DESCRIPTION
## What changed

- Added shared `GITIGNORE_ENTRIES` constant covering all 4 DiffPrism-generated files: `.diffprism`, `.mcp.json`, `.claude/settings.json`, `.claude/skills/review/`
- `setupGitignore()` now adds all entries (appending only missing ones to existing `.gitignore`)
- `teardownGitignore()` now removes all entries via the shared constant
- Tests updated to verify full coverage in both setup and teardown

## Why

Previously only `.diffprism` was added to `.gitignore`, but setup also creates `.mcp.json`, `.claude/settings.json`, and `.claude/skills/review/SKILL.md`. These showed up in `git status` and could be accidentally committed to shared repositories.

## Testing

- `pnpm test` passes (68 CLI tests, 134 total)
- `npx tsc --noEmit -p cli/tsconfig.json` passes
- All new and updated tests verify: creation with all entries, partial append, skip when complete, teardown removal, file deletion when empty, preservation of non-DiffPrism entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)