### PR TITLE
minor: Add live diff watching for global server sessions

### DIFF
--- a/packages/core/src/__tests__/diff-utils.test.ts
+++ b/packages/core/src/__tests__/diff-utils.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { fileKey, hashDiff, detectChangedFiles } from "../diff-utils.js";
+import type { DiffFile, DiffSet } from "../types.js";
+
+function makeFile(overrides: Partial<DiffFile> = {}): DiffFile {
+  return {
+    path: "src/index.ts",
+    status: "modified",
+    hunks: [],
+    language: "typescript",
+    binary: false,
+    additions: 10,
+    deletions: 5,
+    ...overrides,
+  };
+}
+
+function makeDiffSet(files: DiffFile[]): DiffSet {
+  return { baseRef: "HEAD", headRef: "working-copy", files };
+}
+
+describe("fileKey", () => {
+  it("returns plain path when no stage", () => {
+    const file = makeFile({ path: "src/foo.ts" });
+    expect(fileKey(file)).toBe("src/foo.ts");
+  });
+
+  it("returns staged prefix when stage is staged", () => {
+    const file = makeFile({ path: "src/foo.ts", stage: "staged" });
+    expect(fileKey(file)).toBe("staged:src/foo.ts");
+  });
+
+  it("returns unstaged prefix when stage is unstaged", () => {
+    const file = makeFile({ path: "src/foo.ts", stage: "unstaged" });
+    expect(fileKey(file)).toBe("unstaged:src/foo.ts");
+  });
+});
+
+describe("hashDiff", () => {
+  it("returns consistent hash for same input", () => {
+    const hash1 = hashDiff("hello world");
+    const hash2 = hashDiff("hello world");
+    expect(hash1).toBe(hash2);
+  });
+
+  it("returns different hashes for different inputs", () => {
+    const hash1 = hashDiff("hello world");
+    const hash2 = hashDiff("goodbye world");
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("returns a hex string", () => {
+    const hash = hashDiff("test");
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe("detectChangedFiles", () => {
+  it("returns all files when old is null", () => {
+    const newSet = makeDiffSet([
+      makeFile({ path: "a.ts" }),
+      makeFile({ path: "b.ts" }),
+    ]);
+
+    const changed = detectChangedFiles(null, newSet);
+    expect(changed).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("detects added files", () => {
+    const oldSet = makeDiffSet([makeFile({ path: "a.ts" })]);
+    const newSet = makeDiffSet([
+      makeFile({ path: "a.ts" }),
+      makeFile({ path: "b.ts" }),
+    ]);
+
+    const changed = detectChangedFiles(oldSet, newSet);
+    expect(changed).toContain("b.ts");
+    expect(changed).not.toContain("a.ts");
+  });
+
+  it("detects removed files", () => {
+    const oldSet = makeDiffSet([
+      makeFile({ path: "a.ts" }),
+      makeFile({ path: "b.ts" }),
+    ]);
+    const newSet = makeDiffSet([makeFile({ path: "a.ts" })]);
+
+    const changed = detectChangedFiles(oldSet, newSet);
+    expect(changed).toContain("b.ts");
+    expect(changed).not.toContain("a.ts");
+  });
+
+  it("detects modified files (additions changed)", () => {
+    const oldSet = makeDiffSet([makeFile({ path: "a.ts", additions: 5 })]);
+    const newSet = makeDiffSet([makeFile({ path: "a.ts", additions: 10 })]);
+
+    const changed = detectChangedFiles(oldSet, newSet);
+    expect(changed).toContain("a.ts");
+  });
+
+  it("detects modified files (deletions changed)", () => {
+    const oldSet = makeDiffSet([makeFile({ path: "a.ts", deletions: 2 })]);
+    const newSet = makeDiffSet([makeFile({ path: "a.ts", deletions: 8 })]);
+
+    const changed = detectChangedFiles(oldSet, newSet);
+    expect(changed).toContain("a.ts");
+  });
+
+  it("returns empty when nothing changed", () => {
+    const oldSet = makeDiffSet([
+      makeFile({ path: "a.ts", additions: 10, deletions: 5 }),
+    ]);
+    const newSet = makeDiffSet([
+      makeFile({ path: "a.ts", additions: 10, deletions: 5 }),
+    ]);
+
+    const changed = detectChangedFiles(oldSet, newSet);
+    expect(changed).toEqual([]);
+  });
+
+  it("handles staged files independently", () => {
+    const oldSet = makeDiffSet([
+      makeFile({ path: "a.ts", stage: "staged", additions: 5 }),
+    ]);
+    const newSet = makeDiffSet([
+      makeFile({ path: "a.ts", stage: "staged", additions: 5 }),
+      makeFile({ path: "a.ts", stage: "unstaged", additions: 3 }),
+    ]);
+
+    const changed = detectChangedFiles(oldSet, newSet);
+    expect(changed).toContain("unstaged:a.ts");
+    expect(changed).not.toContain("staged:a.ts");
+  });
+});

--- a/packages/core/src/diff-utils.ts
+++ b/packages/core/src/diff-utils.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+import type { DiffFile, DiffSet } from "./types.js";
+
+export function hashDiff(rawDiff: string): string {
+  return createHash("sha256").update(rawDiff).digest("hex");
+}
+
+/**
+ * Get a composite key for a DiffFile that includes the stage prefix
+ * when present, so staged and unstaged entries for the same file
+ * are tracked independently.
+ */
+export function fileKey(file: DiffFile): string {
+  return file.stage ? `${file.stage}:${file.path}` : file.path;
+}
+
+export function detectChangedFiles(
+  oldDiffSet: DiffSet | null,
+  newDiffSet: DiffSet,
+): string[] {
+  if (!oldDiffSet) {
+    return newDiffSet.files.map(fileKey);
+  }
+
+  const oldFiles = new Map(
+    oldDiffSet.files.map((f) => [fileKey(f), f]),
+  );
+
+  const changed: string[] = [];
+  for (const newFile of newDiffSet.files) {
+    const key = fileKey(newFile);
+    const oldFile = oldFiles.get(key);
+    if (!oldFile) {
+      // New file in the diff
+      changed.push(key);
+    } else if (
+      oldFile.additions !== newFile.additions ||
+      oldFile.deletions !== newFile.deletions
+    ) {
+      // Content changed
+      changed.push(key);
+    }
+  }
+
+  // Files that were removed from the diff
+  for (const oldFile of oldDiffSet.files) {
+    if (!newDiffSet.files.some((f) => fileKey(f) === fileKey(oldFile))) {
+      changed.push(fileKey(oldFile));
+    }
+  }
+
+  return changed;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,7 @@ export type {
 
 export { startReview } from "./pipeline.js";
 export { startWatch } from "./watch.js";
+export { hashDiff, detectChangedFiles, fileKey } from "./diff-utils.js";
 export { readWatchFile, readReviewResult, consumeReviewResult } from "./watch-file.js";
 export { startGlobalServer } from "./global-server.js";
 export {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -159,7 +159,8 @@ export type ServerMessage =
 
 export type ClientMessage =
   | { type: "review:submit"; payload: ReviewResult }
-  | { type: "session:select"; payload: { sessionId: string } };
+  | { type: "session:select"; payload: { sessionId: string } }
+  | { type: "session:close"; payload: { sessionId: string } };
 
 // ─── Pipeline Options ───
 
@@ -241,6 +242,7 @@ export interface SessionSummary {
   deletions: number;
   status: GlobalSessionStatus;
   createdAt: number;
+  hasNewChanges?: boolean;
 }
 
 export interface GlobalServerOptions {
@@ -248,6 +250,7 @@ export interface GlobalServerOptions {
   wsPort?: number; // default 24681
   silent?: boolean;
   dev?: boolean;
+  pollInterval?: number; // ms, default 2000
 }
 
 export interface GlobalServerHandle {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -76,7 +76,7 @@ async function reviewViaGlobalServer(
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ payload, projectPath: cwd }),
+      body: JSON.stringify({ payload, projectPath: cwd, diffRef }),
     },
   );
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -6,7 +6,7 @@ import { SessionList } from "./components/SessionList";
 import type { ReviewResult } from "./types";
 
 export default function App() {
-  const { sendResult, selectSession: wsSelectSession, connectionStatus } = useWebSocket();
+  const { sendResult, selectSession: wsSelectSession, closeSession: wsCloseSession, connectionStatus } = useWebSocket();
   const {
     diffSet,
     metadata,
@@ -19,6 +19,7 @@ export default function App() {
     sessions,
     activeSessionId,
     selectSession,
+    removeSession,
   } = useReviewStore();
   const [submitted, setSubmitted] = useState(false);
   const [countdown, setCountdown] = useState(3);
@@ -45,6 +46,11 @@ export default function App() {
   function handleSelectSession(sessionId: string) {
     selectSession(sessionId);
     wsSelectSession(sessionId);
+  }
+
+  function handleCloseSession(sessionId: string) {
+    removeSession(sessionId);
+    wsCloseSession(sessionId);
   }
 
   const closeWindow = useCallback(() => {
@@ -135,6 +141,7 @@ export default function App() {
         sessions={sessions}
         activeSessionId={activeSessionId}
         onSelect={handleSelectSession}
+        onClose={handleCloseSession}
       />
     );
   }

--- a/packages/ui/src/components/SessionList/SessionList.tsx
+++ b/packages/ui/src/components/SessionList/SessionList.tsx
@@ -1,10 +1,11 @@
-import { GitBranch, FileCode, Clock } from "lucide-react";
+import { GitBranch, FileCode, Clock, Radio, X } from "lucide-react";
 import type { SessionSummary } from "../../types";
 
 interface SessionListProps {
   sessions: SessionSummary[];
   activeSessionId: string | null;
   onSelect: (sessionId: string) => void;
+  onClose?: (sessionId: string) => void;
 }
 
 function formatTime(timestamp: number): string {
@@ -40,7 +41,7 @@ function statusBadge(status: SessionSummary["status"]) {
   }
 }
 
-export function SessionList({ sessions, activeSessionId, onSelect }: SessionListProps) {
+export function SessionList({ sessions, activeSessionId, onSelect, onClose }: SessionListProps) {
   if (sessions.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full bg-background text-center px-8">
@@ -76,20 +77,44 @@ export function SessionList({ sessions, activeSessionId, onSelect }: SessionList
           const isActive = session.id === activeSessionId;
 
           return (
-            <button
+            <div
               key={session.id}
-              onClick={() => onSelect(session.id)}
-              className={`w-full text-left px-4 py-3 rounded-lg border transition-colors ${
+              className={`relative w-full text-left px-4 py-3 rounded-lg border transition-colors cursor-pointer ${
                 isActive
                   ? "bg-accent/10 border-accent/40"
                   : "bg-surface border-border hover:border-text-secondary/30"
               }`}
+              onClick={() => onSelect(session.id)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") onSelect(session.id);
+              }}
             >
+              {/* Close button */}
+              {onClose && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onClose(session.id);
+                  }}
+                  className="absolute top-2 right-2 p-1 rounded hover:bg-border/50 text-text-secondary hover:text-text-primary transition-colors"
+                  title="Dismiss session"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              )}
+
               {/* Title + status */}
-              <div className="flex items-center justify-between mb-1.5">
-                <span className="text-text-primary text-sm font-medium truncate mr-2">
-                  {session.title || getProjectName(session.projectPath)}
-                </span>
+              <div className="flex items-center justify-between mb-1.5 pr-6">
+                <div className="flex items-center gap-2 min-w-0 mr-2">
+                  {session.hasNewChanges && (
+                    <Radio className="w-3 h-3 text-accent flex-shrink-0 animate-pulse" />
+                  )}
+                  <span className="text-text-primary text-sm font-medium truncate">
+                    {session.title || getProjectName(session.projectPath)}
+                  </span>
+                </div>
                 {statusBadge(session.status)}
               </div>
 
@@ -126,7 +151,7 @@ export function SessionList({ sessions, activeSessionId, onSelect }: SessionList
                   {formatTime(session.createdAt)}
                 </span>
               </div>
-            </button>
+            </div>
           );
         })}
       </div>

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -108,5 +108,20 @@ export function useWebSocket() {
     ws.send(JSON.stringify(message));
   }, []);
 
-  return { sendResult, selectSession, connectionStatus };
+  const closeSession = useCallback((sessionId: string) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      console.error("WebSocket is not connected");
+      return;
+    }
+
+    const message: ClientMessage = {
+      type: "session:close",
+      payload: { sessionId },
+    };
+
+    ws.send(JSON.stringify(message));
+  }, []);
+
+  return { sendResult, selectSession, closeSession, connectionStatus };
 }

--- a/packages/ui/src/store/review.ts
+++ b/packages/ui/src/store/review.ts
@@ -63,6 +63,7 @@ export interface ReviewState {
   setServerMode: (isServerMode: boolean) => void;
   setSessions: (sessions: SessionSummary[]) => void;
   addSession: (session: SessionSummary) => void;
+  removeSession: (sessionId: string) => void;
   selectSession: (sessionId: string) => void;
   clearReview: () => void;
 }
@@ -243,6 +244,28 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
     set((state) => ({
       sessions: [...state.sessions, session],
     }));
+  },
+
+  removeSession: (sessionId: string) => {
+    const state = get();
+    const isActive = state.activeSessionId === sessionId;
+    set({
+      sessions: state.sessions.filter((s) => s.id !== sessionId),
+      ...(isActive && {
+        reviewId: null,
+        diffSet: null,
+        rawDiff: null,
+        briefing: null,
+        metadata: null,
+        selectedFile: null,
+        fileStatuses: {},
+        comments: [],
+        activeCommentKey: null,
+        activeSessionId: null,
+        watchSubmitted: false,
+        hasUnreviewedChanges: true,
+      }),
+    });
   },
 
   selectSession: (sessionId: string) => {

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -177,6 +177,7 @@ export interface SessionSummary {
   deletions: number;
   status: GlobalSessionStatus;
   createdAt: number;
+  hasNewChanges?: boolean;
 }
 
 export type ServerMessage =
@@ -188,4 +189,5 @@ export type ServerMessage =
 
 export type ClientMessage =
   | { type: "review:submit"; payload: ReviewResult }
-  | { type: "session:select"; payload: { sessionId: string } };
+  | { type: "session:select"; payload: { sessionId: string } }
+  | { type: "session:close"; payload: { sessionId: string } };

--- a/ui-dist/index.html
+++ b/ui-dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>DiffPrism</title>
-    <script type="module" crossorigin src="/assets/index-BfIxxwO-.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BcuyMNeU.css">
+    <script type="module" crossorigin src="/assets/index-C_k3uWX-.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CkUXOfXP.css">
   </head>
   <body style="background-color: var(--color-background); margin: 0;">
     <div id="root"></div>


### PR DESCRIPTION
## Summary

- **Live diff updates** — Global server sessions now poll for changes and send `diff:update` messages to active viewers in real-time (same behavior as watch mode)
- **"New changes" indicator** — Session list shows a pulsing indicator when a session's diff has changed since last viewed, resets when the session is selected
- **Close/dismiss sessions** — Users can remove sessions from the list via an X button, which stops polling and cleans up the session
- **Shared diff utilities** — Extracted `hashDiff()`, `fileKey()`, `detectChangedFiles()` from `watch.ts` into `diff-utils.ts` for reuse by the global server
- **MCP sends `diffRef`** — Enables the global server to re-poll the same git diff reference

## What changed

| File | Change |
|------|--------|
| `packages/core/src/diff-utils.ts` | **NEW** — shared diff comparison utilities |
| `packages/core/src/watch.ts` | Refactored to import from diff-utils |
| `packages/core/src/types.ts` | Added `pollInterval`, `hasNewChanges`, `session:close` |
| `packages/ui/src/types.ts` | Mirrored type changes |
| `packages/core/src/global-server.ts` | Session watcher management, poll loop, lifecycle hooks |
| `packages/mcp-server/src/index.ts` | Send `diffRef` in POST body |
| `packages/ui/src/components/SessionList/SessionList.tsx` | New changes indicator, close button |
| `packages/ui/src/hooks/useWebSocket.ts` | Added `closeSession()` |
| `packages/ui/src/store/review.ts` | Added `removeSession()` |
| `packages/core/src/index.ts` | Export new utilities |

## Testing
- `pnpm test` passes (217 tests across all packages)
- `pnpm run build` passes
- Type-check passes for core, mcp-server, and UI packages
- New tests: 13 for diff-utils, 4 for global-server watcher behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)