### PR TITLE
patch: Update outdated docs to reflect v0.21.0 feature state

### DIFF
--- a/docs/dev-testing.md
+++ b/docs/dev-testing.md
@@ -8,11 +8,15 @@ All CLI commands can be run directly from source using `tsx`, bypassing the inst
 # Review (one-shot, blocks until submitted)
 npx tsx cli/src/index.ts review --dev
 
-# Watch (persistent, live-updating)
+# Start (setup + watch in one command)
+npx tsx cli/src/index.ts start --dev
+
+# Watch (persistent, live-updating — no setup step)
 npx tsx cli/src/index.ts watch --dev
 
 # Or use the pnpm alias
 pnpm cli review --dev
+pnpm cli start --dev
 pnpm cli watch --dev
 ```
 
@@ -37,7 +41,7 @@ pnpm cli review --dev all
 pnpm cli review --dev HEAD~3..HEAD
 ```
 
-Same flags work with `watch`.
+Same flags work with `watch` and `start`.
 
 ## Testing the MCP server
 
@@ -74,7 +78,7 @@ pnpm run build
 
 ### UI development
 
-1. Start watch in dev mode: `pnpm cli watch --dev`
+1. Start watch in dev mode: `pnpm cli start --dev` (or `pnpm cli watch --dev` if already set up)
 2. Edit files in `packages/ui/src/` — changes hot-reload in the browser
 3. Submit a review to test the submit flow, watch keeps running
 

--- a/docs/landing-page-update-prompt.md
+++ b/docs/landing-page-update-prompt.md
@@ -17,7 +17,7 @@ Three operational modes:
 
 ## What's New Since the Last Landing Page Update
 
-### Major: Global Server / Multi-Session Mode (v0.15.0–v0.20.2)
+### Major: Global Server / Multi-Session Mode (v0.15.0–v0.21.0)
 This is the headline new capability. `diffprism server` starts a persistent process (HTTP port 24680 + WS port 24681) that:
 - Accepts reviews from **multiple Claude Code sessions** simultaneously
 - Presents a **session dashboard** in a single browser tab — showing all pending/in-review/submitted reviews with status badges, branch names, file counts, and change stats
@@ -36,7 +36,7 @@ This enables the core vision: developers using git worktrees to run multiple age
 - **Agent reasoning panel** — Collapsible panel showing why the agent made changes
 - **Global setup** — `diffprism setup --global` configures at `~/.claude/` paths, no git repo required. Auto-runs on `diffprism server` start.
 - **Teardown command** — `diffprism teardown` cleanly reverses all setup changes (MCP config, hooks, skill, gitignore)
-- **v0.20.2 is current version**
+- **v0.21.0 is current version**
 
 ## Current Landing Page Structure
 

--- a/docs/ux-design-notes.md
+++ b/docs/ux-design-notes.md
@@ -6,20 +6,25 @@ Living document capturing user experience observations, design decisions, and ex
 
 ## CLI Defaults
 
-### Default diff scope (v0.2.6)
-- **Decision:** `diffprism review` with no flags defaults to `"all"` (staged + unstaged via `git diff HEAD`)
-- **Rationale:** Most users edit files and run the review without staging first. Defaulting to `"staged"` caused "No changes to review" confusion. Explicit `--staged` and `--unstaged` flags still available for narrower scope.
-- **Issue:** [#6](https://github.com/CodeJonesW/diffprism/issues/6)
+### Default diff scope
+- **v0.2.6:** Changed default from `"staged"` to `"all"` (staged + unstaged via `git diff HEAD`) because defaulting to staged caused "No changes to review" confusion. [#6](https://github.com/CodeJonesW/diffprism/issues/6)
+- **v0.13.x:** Changed default from `"all"` to `"working-copy"` — staged and unstaged changes are shown as separate groups in the UI, giving reviewers better context about what's been deliberately staged vs. still in progress. Explicit `--staged` and `--unstaged` flags still available for narrower scope.
 
 ---
 
 ## Review UI
 
-### Current state (M0)
-- Dark mode only, GitHub dark theme colors
-- Unified diff view with syntax highlighting (refractor)
-- Two actions: Approve / Request Changes
-- No inline commenting yet
+### Current state (v0.21.0)
+- Dark/light mode toggle with theme persistence (v0.9.0)
+- Unified + split (side-by-side) diff view toggle (v0.6.0)
+- Syntax highlighting via refractor v4
+- Three review decisions: Approve / Request Changes / Approve with Comments
+- Inline line-level commenting — click any line to add a comment (v0.8.0)
+- Comment types: must_fix, suggestion, question, nitpick (v0.8.0)
+- File-level status tracking: unreviewed, reviewed, approved, needs_changes (v0.7.0)
+- Keyboard shortcuts: j/k navigate files, s cycles file status, ? opens hotkey guide (v0.2.12)
+- Agent reasoning display in collapsible context panel (v0.5.0)
+- Review briefing bar: complexity scoring, test coverage gaps, pattern flags (v0.3.0+)
 
 ### Observations
 - (Add observations here as they arise from real usage)


### PR DESCRIPTION
## Summary
- **ux-design-notes:** Replace stale M0 "current state" (dark-only, no commenting, 2 actions) with accurate v0.21.0 feature list; add working-copy default history
- **claude-setup:** Add `get_review_result` params (`wait`, `timeout`), `working-copy` diff_ref, expanded ReviewResult fields, fix config defaults
- **dev-testing:** Add `start` command throughout, update common workflows
- **landing-page-update-prompt:** Bump version references to v0.21.0

## Test plan
- [ ] Docs read accurately against current codebase behavior
- [ ] No broken links or formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)