### PR TITLE
patch: Return to session list after review submission in server mode

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -20,6 +20,7 @@ export default function App() {
     activeSessionId,
     selectSession,
     removeSession,
+    clearReview,
   } = useReviewStore();
   const [submitted, setSubmitted] = useState(false);
   const [countdown, setCountdown] = useState(3);
@@ -36,7 +37,9 @@ export default function App() {
 
   function handleSubmit(result: ReviewResult) {
     sendResult(result);
-    if (isWatchMode || isServerMode) {
+    if (isServerMode) {
+      clearReview();
+    } else if (isWatchMode) {
       setWatchSubmitted(true);
     } else {
       setSubmitted(true);


### PR DESCRIPTION
## What changed

In server mode, submitting a review now calls `clearReview()` to reset the store, returning the UI to the session list instead of staying on the submitted review with a "watching for changes" banner.

- **Server mode**: After submit → returns to session list to pick up the next review
- **Watch mode**: Unchanged — stays on review with green "watching for changes" banner
- **Ephemeral mode**: Unchanged — shows submitted confirmation + 3s close countdown

## Why

In multi-session (global server) mode, after submitting a review the user expects to return to the session list to pick up the next pending review, not stay on a completed review.

## Testing

- `pnpm test` passes (231 tests)
- Manual: server mode submit → returns to session list
- Manual: ephemeral/watch modes unchanged

## Release notes

In server mode, submitting a review now returns to the session list instead of staying on the submitted review with a "watching for changes" banner. This lets users immediately pick up the next pending review. Watch mode and ephemeral mode behavior are unchanged.