### PR TITLE
minor: add browser notifications for new review sessions

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,22 +9,23 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "lucide-react": "^0.469.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
     "react-diff-view": "^3.2.1",
+    "react-dom": "^19.0.0",
     "refractor": "^4.8.1",
-    "zustand": "^5.0.0",
-    "lucide-react": "^0.469.0"
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "autoprefixer": "^10.4.20",
+    "jsdom": "^26.0.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.0",
-    "jsdom": "^26.0.0",
     "vite": "^6.0.0",
     "vitest": "^3.0.0"
   }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useCallback } from "react";
 import { useWebSocket } from "./hooks/useWebSocket";
+import { useNotifications } from "./hooks/useNotifications";
 import { useReviewStore } from "./store/review";
 import { ReviewView } from "./components/ReviewView";
 import { SessionList } from "./components/SessionList";
 import type { ReviewResult } from "./types";
 
 export default function App() {
-  const { sendResult, selectSession: wsSelectSession, closeSession: wsCloseSession, connectionStatus } = useWebSocket();
+  const { permission: notificationPermission, enabled: notificationsEnabled, toggle: toggleNotifications, notifyNewSession } = useNotifications({ onSessionSelect: handleSelectSession });
+  const { sendResult, selectSession: wsSelectSession, closeSession: wsCloseSession, connectionStatus } = useWebSocket({ onSessionAdded: notifyNewSession });
   const {
     diffSet,
     metadata,
@@ -158,6 +160,9 @@ export default function App() {
           activeSessionId={activeSessionId}
           onSelect={handleSelectSession}
           onClose={handleCloseSession}
+          notificationPermission={notificationPermission}
+          notificationsEnabled={notificationsEnabled}
+          onToggleNotifications={toggleNotifications}
         />
       </div>
     );

--- a/packages/ui/src/__tests__/notifications.test.ts
+++ b/packages/ui/src/__tests__/notifications.test.ts
@@ -1,0 +1,304 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useNotifications } from "../hooks/useNotifications.js";
+import type { SessionSummary } from "../types.js";
+
+function makeSession(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: "session-abc",
+    projectPath: "/test/project",
+    branch: "feature-branch",
+    title: "Test review",
+    fileCount: 3,
+    additions: 10,
+    deletions: 5,
+    status: "pending",
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+// Store created Notification instances for inspection
+let notificationInstances: Array<{
+  title: string;
+  options: NotificationOptions;
+  onclick: ((this: Notification, ev: Event) => unknown) | null;
+  close: ReturnType<typeof vi.fn>;
+}>;
+
+function setupNotificationMock(permission: NotificationPermission = "default") {
+  notificationInstances = [];
+
+  const MockNotification = vi.fn((title: string, options: NotificationOptions) => {
+    const instance = {
+      title,
+      options,
+      onclick: null as ((this: Notification, ev: Event) => unknown) | null,
+      close: vi.fn(),
+    };
+    notificationInstances.push(instance);
+    return instance;
+  }) as unknown as typeof Notification;
+
+  Object.defineProperty(MockNotification, "permission", {
+    get: () => permission,
+    configurable: true,
+  });
+
+  MockNotification.requestPermission = vi.fn(async () => {
+    permission = "granted";
+    Object.defineProperty(MockNotification, "permission", {
+      get: () => permission,
+      configurable: true,
+    });
+    return "granted" as NotificationPermission;
+  });
+
+  Object.defineProperty(globalThis, "Notification", {
+    value: MockNotification,
+    writable: true,
+    configurable: true,
+  });
+
+  return MockNotification;
+}
+
+function setVisibilityState(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    value: state,
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe("useNotifications", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    notificationInstances = [];
+    setVisibilityState("visible");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("feature detection", () => {
+    it("returns denied permission and no-op functions when Notification API is unavailable", () => {
+      // Remove Notification from globalThis
+      const original = globalThis.Notification;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (globalThis as any).Notification;
+
+      const { result } = renderHook(() => useNotifications());
+
+      expect(result.current.permission).toBe("denied");
+      expect(result.current.enabled).toBe(true); // preference is still read from localStorage
+
+      // Should not throw
+      act(() => {
+        result.current.notifyNewSession(makeSession());
+      });
+
+      // Restore
+      globalThis.Notification = original;
+    });
+  });
+
+  describe("tab focused", () => {
+    it("does not show notification when tab is visible", async () => {
+      setupNotificationMock("granted");
+      setVisibilityState("visible");
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        result.current.notifyNewSession(makeSession());
+      });
+
+      expect(notificationInstances).toHaveLength(0);
+    });
+  });
+
+  describe("tab hidden + granted", () => {
+    it("creates notification with correct content", async () => {
+      setupNotificationMock("granted");
+      setVisibilityState("hidden");
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        result.current.notifyNewSession(makeSession());
+      });
+
+      expect(notificationInstances).toHaveLength(1);
+      expect(notificationInstances[0].title).toBe("Test review");
+      expect(notificationInstances[0].options.body).toBe(
+        "feature-branch · 3 files, +10 -5",
+      );
+      expect(notificationInstances[0].options.icon).toBe("/favicon.svg");
+      expect(notificationInstances[0].options.tag).toBe("session-abc");
+    });
+
+    it("uses fallback title when session has no title", async () => {
+      setupNotificationMock("granted");
+      setVisibilityState("hidden");
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        result.current.notifyNewSession(makeSession({ title: undefined }));
+      });
+
+      expect(notificationInstances).toHaveLength(1);
+      expect(notificationInstances[0].title).toBe("New Review Ready");
+    });
+
+    it("handles session without branch", async () => {
+      setupNotificationMock("granted");
+      setVisibilityState("hidden");
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        result.current.notifyNewSession(makeSession({ branch: undefined }));
+      });
+
+      expect(notificationInstances).toHaveLength(1);
+      expect(notificationInstances[0].options.body).toBe("3 files, +10 -5");
+    });
+  });
+
+  describe("permission denied", () => {
+    it("does not create notification", async () => {
+      setupNotificationMock("denied");
+      setVisibilityState("hidden");
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        result.current.notifyNewSession(makeSession());
+      });
+
+      expect(notificationInstances).toHaveLength(0);
+    });
+  });
+
+  describe("permission default", () => {
+    it("auto-requests permission and notifies if granted", async () => {
+      const mock = setupNotificationMock("default");
+      setVisibilityState("hidden");
+
+      const { result } = renderHook(() => useNotifications());
+
+      expect(result.current.permission).toBe("default");
+
+      await act(async () => {
+        result.current.notifyNewSession(makeSession());
+      });
+
+      expect(mock.requestPermission).toHaveBeenCalled();
+      expect(notificationInstances).toHaveLength(1);
+    });
+
+    it("does not notify if permission request is denied", async () => {
+      const mock = setupNotificationMock("default");
+      // Override requestPermission to deny
+      mock.requestPermission = vi.fn(async () => {
+        Object.defineProperty(mock, "permission", {
+          get: () => "denied" as NotificationPermission,
+          configurable: true,
+        });
+        return "denied" as NotificationPermission;
+      });
+      setVisibilityState("hidden");
+
+      const { result } = renderHook(() => useNotifications());
+
+      await act(async () => {
+        result.current.notifyNewSession(makeSession());
+      });
+
+      expect(mock.requestPermission).toHaveBeenCalled();
+      expect(notificationInstances).toHaveLength(0);
+    });
+  });
+
+  describe("localStorage preference", () => {
+    it("suppresses notification when disabled even if granted", async () => {
+      setupNotificationMock("granted");
+      setVisibilityState("hidden");
+      localStorage.setItem("diffprism-notifications", "disabled");
+
+      const { result } = renderHook(() => useNotifications());
+
+      expect(result.current.enabled).toBe(false);
+
+      await act(async () => {
+        result.current.notifyNewSession(makeSession());
+      });
+
+      expect(notificationInstances).toHaveLength(0);
+    });
+
+    it("toggle flips from enabled to disabled", () => {
+      setupNotificationMock("granted");
+
+      const { result } = renderHook(() => useNotifications());
+
+      expect(result.current.enabled).toBe(true);
+
+      act(() => {
+        result.current.toggle();
+      });
+
+      expect(result.current.enabled).toBe(false);
+      expect(localStorage.getItem("diffprism-notifications")).toBe("disabled");
+    });
+
+    it("toggle flips from disabled to enabled", () => {
+      setupNotificationMock("granted");
+      localStorage.setItem("diffprism-notifications", "disabled");
+
+      const { result } = renderHook(() => useNotifications());
+
+      expect(result.current.enabled).toBe(false);
+
+      act(() => {
+        result.current.toggle();
+      });
+
+      expect(result.current.enabled).toBe(true);
+      expect(localStorage.getItem("diffprism-notifications")).toBe("enabled");
+    });
+  });
+
+  describe("notification click", () => {
+    it("calls window.focus, onSessionSelect, and closes notification", async () => {
+      setupNotificationMock("granted");
+      setVisibilityState("hidden");
+
+      const onSessionSelect = vi.fn();
+      const focusSpy = vi.spyOn(window, "focus").mockImplementation(() => {});
+
+      const { result } = renderHook(() =>
+        useNotifications({ onSessionSelect }),
+      );
+
+      await act(async () => {
+        result.current.notifyNewSession(makeSession({ id: "click-test" }));
+      });
+
+      expect(notificationInstances).toHaveLength(1);
+
+      // Simulate click
+      const instance = notificationInstances[0];
+      expect(instance.onclick).toBeTypeOf("function");
+      instance.onclick!.call(null as unknown as Notification, new Event("click"));
+
+      expect(focusSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect(onSessionSelect).toHaveBeenCalledWith("click-test");
+      expect(instance.close).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ui/src/components/NotificationToggle/NotificationToggle.tsx
+++ b/packages/ui/src/components/NotificationToggle/NotificationToggle.tsx
@@ -1,0 +1,40 @@
+import { Bell, BellOff } from "lucide-react";
+import type { NotificationPermission } from "../../hooks/useNotifications.js";
+
+interface NotificationToggleProps {
+  permission: NotificationPermission;
+  enabled: boolean;
+  onToggle: () => void;
+}
+
+export function NotificationToggle({ permission, enabled, onToggle }: NotificationToggleProps) {
+  const isDenied = permission === "denied";
+  const isActive = permission === "granted" && enabled;
+
+  const title = isDenied
+    ? "Notifications blocked by browser"
+    : isActive
+      ? "Notifications on"
+      : "Enable notifications";
+
+  return (
+    <button
+      onClick={onToggle}
+      disabled={isDenied}
+      className={`p-1.5 rounded transition-colors cursor-pointer ${
+        isDenied
+          ? "text-text-secondary/50 cursor-not-allowed"
+          : isActive
+            ? "text-accent hover:text-accent/80"
+            : "text-text-secondary hover:text-text-primary"
+      }`}
+      title={title}
+    >
+      {isActive ? (
+        <Bell className="w-4 h-4" />
+      ) : (
+        <BellOff className="w-4 h-4" />
+      )}
+    </button>
+  );
+}

--- a/packages/ui/src/components/NotificationToggle/index.ts
+++ b/packages/ui/src/components/NotificationToggle/index.ts
@@ -1,0 +1,1 @@
+export { NotificationToggle } from "./NotificationToggle";

--- a/packages/ui/src/components/SessionList/SessionList.tsx
+++ b/packages/ui/src/components/SessionList/SessionList.tsx
@@ -1,4 +1,6 @@
 import { GitBranch, FileCode, Clock, Radio, X } from "lucide-react";
+import { NotificationToggle } from "../NotificationToggle";
+import type { NotificationPermission } from "../../hooks/useNotifications.js";
 import type { SessionSummary } from "../../types";
 
 interface SessionListProps {
@@ -6,6 +8,9 @@ interface SessionListProps {
   activeSessionId: string | null;
   onSelect: (sessionId: string) => void;
   onClose?: (sessionId: string) => void;
+  notificationPermission?: NotificationPermission;
+  notificationsEnabled?: boolean;
+  onToggleNotifications?: () => void;
 }
 
 function formatTime(timestamp: number): string {
@@ -70,10 +75,19 @@ function statusBadge(session: SessionSummary) {
   );
 }
 
-export function SessionList({ sessions, activeSessionId, onSelect, onClose }: SessionListProps) {
+export function SessionList({ sessions, activeSessionId, onSelect, onClose, notificationPermission, notificationsEnabled, onToggleNotifications }: SessionListProps) {
   if (sessions.length === 0) {
     return (
       <div className="flex flex-col h-full bg-background">
+        {onToggleNotifications && notificationPermission && (
+          <div className="flex justify-end px-6 pt-4">
+            <NotificationToggle
+              permission={notificationPermission}
+              enabled={notificationsEnabled ?? false}
+              onToggle={onToggleNotifications}
+            />
+          </div>
+        )}
         <div className="flex flex-1 flex-col items-center justify-center text-center px-8">
           <div className="w-12 h-12 rounded-full bg-surface border border-border flex items-center justify-center mb-4">
             <FileCode className="w-6 h-6 text-text-secondary" />
@@ -93,13 +107,22 @@ export function SessionList({ sessions, activeSessionId, onSelect, onClose }: Se
   return (
     <div className="flex flex-col h-full bg-background">
       {/* Header */}
-      <div className="px-6 py-4 border-b border-border">
-        <h2 className="text-text-primary text-sm font-semibold">
-          Review Sessions
-        </h2>
-        <span className="text-text-secondary text-xs">
-          {sessions.length} session{sessions.length !== 1 ? "s" : ""}
-        </span>
+      <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+        <div>
+          <h2 className="text-text-primary text-sm font-semibold">
+            Review Sessions
+          </h2>
+          <span className="text-text-secondary text-xs">
+            {sessions.length} session{sessions.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+        {onToggleNotifications && notificationPermission && (
+          <NotificationToggle
+            permission={notificationPermission}
+            enabled={notificationsEnabled ?? false}
+            onToggle={onToggleNotifications}
+          />
+        )}
       </div>
 
       {/* Session cards */}

--- a/packages/ui/src/hooks/useNotifications.ts
+++ b/packages/ui/src/hooks/useNotifications.ts
@@ -1,0 +1,112 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { SessionSummary } from "../types.js";
+
+export type NotificationPermission = "default" | "granted" | "denied";
+
+const STORAGE_KEY = "diffprism-notifications";
+
+function getStoredPreference(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== "disabled";
+  } catch {
+    return true;
+  }
+}
+
+function setStoredPreference(enabled: boolean): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, enabled ? "enabled" : "disabled");
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+interface UseNotificationsOptions {
+  onSessionSelect?: (sessionId: string) => void;
+}
+
+interface UseNotificationsReturn {
+  permission: NotificationPermission;
+  enabled: boolean;
+  toggle: () => void;
+  notifyNewSession: (session: SessionSummary) => void;
+}
+
+export function useNotifications(options?: UseNotificationsOptions): UseNotificationsReturn {
+  const onSessionSelectRef = useRef(options?.onSessionSelect);
+  useEffect(() => {
+    onSessionSelectRef.current = options?.onSessionSelect;
+  }, [options?.onSessionSelect]);
+
+  const hasNotificationApi = typeof globalThis.Notification !== "undefined";
+
+  const [permission, setPermission] = useState<NotificationPermission>(() =>
+    hasNotificationApi ? (Notification.permission as NotificationPermission) : "denied",
+  );
+  const [enabled, setEnabled] = useState(getStoredPreference);
+
+  const requestPermission = useCallback(async (): Promise<NotificationPermission> => {
+    if (!hasNotificationApi) return "denied";
+    const result = await Notification.requestPermission();
+    const perm = result as NotificationPermission;
+    setPermission(perm);
+    return perm;
+  }, [hasNotificationApi]);
+
+  const toggle = useCallback(async () => {
+    if (!hasNotificationApi) return;
+
+    if (permission === "denied") return;
+
+    if (permission === "default") {
+      const result = await requestPermission();
+      if (result === "granted") {
+        setEnabled(true);
+        setStoredPreference(true);
+      }
+      return;
+    }
+
+    // permission === "granted" — toggle preference
+    const next = !enabled;
+    setEnabled(next);
+    setStoredPreference(next);
+  }, [hasNotificationApi, permission, enabled, requestPermission]);
+
+  const notifyNewSession = useCallback(
+    async (session: SessionSummary) => {
+      if (!hasNotificationApi) return;
+      if (document.visibilityState !== "hidden") return;
+      if (!enabled) return;
+
+      let currentPermission = permission;
+      if (currentPermission === "default") {
+        currentPermission = await requestPermission();
+      }
+      if (currentPermission !== "granted") return;
+
+      const title = session.title || "New Review Ready";
+      const parts: string[] = [];
+      if (session.branch) parts.push(session.branch);
+      parts.push(
+        `${session.fileCount} file${session.fileCount !== 1 ? "s" : ""}, +${session.additions} -${session.deletions}`,
+      );
+      const body = parts.join(" · ");
+
+      const notification = new Notification(title, {
+        body,
+        icon: "/favicon.svg",
+        tag: session.id,
+      });
+
+      notification.onclick = () => {
+        window.focus();
+        onSessionSelectRef.current?.(session.id);
+        notification.close();
+      };
+    },
+    [hasNotificationApi, enabled, permission, requestPermission],
+  );
+
+  return { permission, enabled, toggle, notifyNewSession };
+}

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -1,9 +1,16 @@
 import { useEffect, useRef, useCallback } from "react";
 import { useReviewStore } from "../store/review";
-import type { ReviewResult, ServerMessage, ClientMessage } from "../types";
+import type { ReviewResult, ServerMessage, ClientMessage, SessionSummary } from "../types";
 
-export function useWebSocket() {
+interface UseWebSocketOptions {
+  onSessionAdded?: (session: SessionSummary) => void;
+}
+
+export function useWebSocket(options?: UseWebSocketOptions) {
   const wsRef = useRef<WebSocket | null>(null);
+  const onSessionAddedRef = useRef(options?.onSessionAdded);
+  onSessionAddedRef.current = options?.onSessionAdded;
+
   const {
     connectionStatus,
     setConnectionStatus,
@@ -60,6 +67,7 @@ export function useWebSocket() {
           setSessions(message.payload);
         } else if (message.type === "session:added") {
           addSession(message.payload);
+          onSessionAddedRef.current?.(message.payload);
         } else if (message.type === "session:updated") {
           updateSession(message.payload);
         } else if (message.type === "session:removed") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
         specifier: ^5.0.0
         version: 5.0.11(@types/react@19.2.14)(react@19.2.4)
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -272,6 +275,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -797,6 +804,28 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -900,6 +929,14 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -909,6 +946,9 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1099,6 +1139,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -1107,6 +1151,9 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1455,6 +1502,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1637,6 +1688,10 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
 
@@ -1672,6 +1727,9 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -2208,6 +2266,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.28.6': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -2541,6 +2601,29 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.0
@@ -2669,6 +2752,10 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -2677,6 +2764,10 @@ snapshots:
       picomatch: 2.3.1
 
   arg@5.0.2: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -2848,11 +2939,15 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   didyoumean@1.2.2: {}
 
   diff-match-patch@1.0.5: {}
 
   dlv@1.1.3: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3254,6 +3349,8 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3405,6 +3502,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   property-information@6.5.0: {}
 
   proxy-addr@2.0.7:
@@ -3443,6 +3546,8 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
 


### PR DESCRIPTION
## What changed

- Added Web Notifications API support so users get desktop notifications when a new review session arrives while the DiffPrism tab is backgrounded
- Added a bell toggle (NotificationToggle component) in the session list header for enabling/disabling notifications, with preference persisted in localStorage
- Added `onSessionAdded` callback to `useWebSocket` hook to trigger notifications on `session:added` events
- Click-to-focus interaction: clicking a notification focuses the tab and selects the session

## Why

When the global server is running and an agent submits a review, the UI updates the session list via WebSocket. But if the browser tab is in the background, the user has no way to know a review is waiting. This closes that gap with native desktop notifications.

## New files

| File | Purpose |
|------|---------|
| `packages/ui/src/hooks/useNotifications.ts` | Hook: permission management, localStorage pref, notification creation |
| `packages/ui/src/components/NotificationToggle/` | Bell/BellOff toggle component (follows ThemeToggle pattern) |
| `packages/ui/src/__tests__/notifications.test.ts` | 12 tests covering feature detection, visibility, permissions, localStorage, click handling |

## Testing

- `pnpm test` — all 246 tests pass (12 new notification tests)
- `npx tsc --noEmit -p packages/ui/tsconfig.json` — type-check clean
- Manual: start `diffprism server`, open UI, background tab, trigger `open_review` → notification appears, click focuses tab and selects session

🤖 Generated with [Claude Code](https://claude.com/claude-code)