### PR TITLE
minor: Add quick action menu to file browser header

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -53,11 +53,14 @@ export interface ReviewComment {
   type: "must_fix" | "suggestion" | "question" | "nitpick";
 }
 
+export type PostReviewAction = "commit" | "commit_and_pr";
+
 export interface ReviewResult {
   decision: ReviewDecision;
   comments: ReviewComment[];
   fileStatuses?: Record<string, FileReviewStatus>;
   summary?: string;
+  postReviewAction?: PostReviewAction;
 }
 
 // ─── Analysis / Briefing Types ───

--- a/packages/ui/src/components/ReviewView.tsx
+++ b/packages/ui/src/components/ReviewView.tsx
@@ -22,7 +22,7 @@ export function ReviewView({ onSubmit, onDismiss, isWatchMode, watchSubmitted, h
       <div className="flex flex-1 min-h-0">
         {/* Left sidebar — File Browser */}
         <div className="w-[280px] flex-shrink-0">
-          <FileBrowser />
+          <FileBrowser onSubmit={onSubmit} />
         </div>
 
         {/* Main area — Diff Viewer */}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -54,11 +54,14 @@ export interface ReviewComment {
   type: "must_fix" | "suggestion" | "question" | "nitpick";
 }
 
+export type PostReviewAction = "commit" | "commit_and_pr";
+
 export interface ReviewResult {
   decision: ReviewDecision;
   comments: ReviewComment[];
   fileStatuses?: Record<string, FileReviewStatus>;
   summary?: string;
+  postReviewAction?: PostReviewAction;
 }
 
 // ─── Analysis / Briefing Types ───

--- a/ui-dist/index.html
+++ b/ui-dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>DiffPrism</title>
-    <script type="module" crossorigin src="/assets/index-BNWWckZG.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-8f7wgaXb.css">
+    <script type="module" crossorigin src="/assets/index-tWVXH8Ao.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-C2DDx5SI.css">
   </head>
   <body style="background-color: var(--color-background); margin: 0;">
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Adds a ⋮ dropdown menu to the FileBrowser header with two quick actions: **Approve & Commit** and **Approve, Commit & PR**
- Introduces `PostReviewAction` type (`"commit" | "commit_and_pr"`) as an optional field on `ReviewResult`
- Backwards compatible — the new field is optional, so existing consumers are unaffected

## Test plan
- [x] `pnpm test` — all 231 tests pass
- [x] `pnpm run build` — TypeScript compiles, Vite builds
- [ ] Manual: verify ⋮ menu appears in file browser header, dropdown shows two items, clicking submits review with correct `postReviewAction`

🤖 Generated with [Claude Code](https://claude.com/claude-code)