### PR TITLE
patch: execute postReviewAction from review UI without confirmation

### DIFF
--- a/cli/src/templates/skill.ts
+++ b/cli/src/templates/skill.ts
@@ -52,6 +52,15 @@ The tool blocks until the user submits their review in the browser. When it retu
 - **\`approved_with_comments\`** — Note the comments, address any actionable feedback.
 - **\`changes_requested\`** — Read the comments carefully, make the requested changes, and offer to open another review.
 
+#### Post-Review Actions
+
+The result may include a \`postReviewAction\` field. If present, **execute the action immediately without asking for confirmation** — the user already chose this action in the review UI:
+
+- **\`"commit"\`** — Commit the reviewed changes (stage relevant files, create a commit with an appropriate message).
+- **\`"commit_and_pr"\`** — Commit the changes and open a pull request.
+
+If \`postReviewAction\` is not present or is empty, do nothing extra — just report the result.
+
 ### 5. Error Handling
 
 If the \`mcp__diffprism__open_review\` tool is not available:


### PR DESCRIPTION
## What changed
Updated the `/review` skill template to handle the `postReviewAction` field returned by the review UI. When the user selects "Commit" or "Commit & PR" in the review UI, Claude now executes the action immediately instead of asking a follow-up question.

## Why
The user already made their choice in the review UI — asking again in the CLI is redundant friction.

## Testing
- `pnpm test` passes
- `pnpm run build` passes
- Manually verified the skill template renders correctly via `diffprism setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)