### PR TITLE
patch: update docs for v0.22–v0.24.1 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ DiffPrism gives you a visual review step for AI-written code — stage your chan
 - **Agent reasoning panel** — see why the AI made each change
 - **Dark/light mode** — toggle with theme persistence
 - **Keyboard shortcuts** — `j`/`k` navigate files, `s` cycles file status, `Cmd/Ctrl+Enter` saves comments, `?` toggles hotkey guide
-- **Three-way decisions** — approve, request changes, or approve with comments
+- **Four review decisions** — approve, request changes, approve with comments, or dismiss
+- **Quick actions** — Approve & Commit or Approve, Commit & PR directly from the review UI via the ⋮ menu; the agent executes the action automatically
 - **Branch display** — current git branch shown in the review header
 - **Global server mode** — `diffprism server` runs a persistent multi-session review server, multiple agents post reviews to one browser tab
 - **Multi-session UI** — session list with live status badges, branch info, file counts, and change stats; stale sessions auto-expire
+- **Desktop notifications** — native browser notifications when new review sessions arrive while the tab is backgrounded (global server mode)
 - **One-command setup & teardown** — `diffprism setup` configures Claude Code integration, `diffprism teardown` cleanly reverses it
 
 ## Quick Start
@@ -71,7 +73,7 @@ diffprism review main..feature-branch
 diffprism review --staged --title "Add auth middleware"
 ```
 
-A browser window opens with the diff viewer. Review the changes and click **Approve**, **Request Changes**, or **Approve with Comments**.
+A browser window opens with the diff viewer. Review the changes and click **Approve**, **Request Changes**, **Approve with Comments**, or **Dismiss**. Use the ⋮ menu for quick actions like Approve & Commit.
 
 ### Quick Start (setup + watch in one command)
 
@@ -190,9 +192,10 @@ Fetches the most recent review result from a DiffPrism session (watch mode or gl
 
 | Field | Description |
 |-------|-------------|
-| `decision` | `approved`, `changes_requested`, or `approved_with_comments` |
+| `decision` | `approved`, `changes_requested`, `approved_with_comments`, or `dismissed` |
 | `comments` | Array of inline comments with file, line, body, and type (`must_fix`, `suggestion`, `question`, `nitpick`) |
 | `summary` | Optional reviewer summary |
+| `postReviewAction` | Optional: `"commit"` or `"commit_and_pr"` — set when user selects a quick action from the ⋮ menu |
 
 ## How It Works
 

--- a/docs/claude-setup.md
+++ b/docs/claude-setup.md
@@ -153,7 +153,7 @@ Or be explicit:
 Use the open_review tool with diff_ref "HEAD~1..HEAD" and title "Test review"
 ```
 
-Claude will call the `open_review` MCP tool. A browser window should open with the DiffPrism diff viewer. Submit a review decision (Approve / Request Changes / Approve with Comments), and the result is returned to Claude as structured JSON.
+Claude will call the `open_review` MCP tool. A browser window should open with the DiffPrism diff viewer. Submit a review decision (Approve / Request Changes / Approve with Comments / Dismiss), and the result is returned to Claude as structured JSON. You can also use the ⋮ quick action menu to Approve & Commit or Approve, Commit & PR in one step.
 
 ## Tool Reference
 
@@ -200,10 +200,11 @@ Fetches the most recent review result from a `diffprism watch` session. The resu
 }
 ```
 
-- `decision` — one of: `approved`, `changes_requested`, or `approved_with_comments`
+- `decision` — one of: `approved`, `changes_requested`, `approved_with_comments`, or `dismissed`
 - `comments` — array of `{ file, line, body, type }` where type is `must_fix`, `suggestion`, `question`, or `nitpick`
 - `fileStatuses` — (optional) map of file path to review status (`unreviewed`, `reviewed`, `approved`, `needs_changes`)
 - `summary` — (optional) free-text summary from the reviewer
+- `postReviewAction` — (optional) `"commit"` or `"commit_and_pr"` — set when the user selects a quick action from the ⋮ menu in the review UI
 
 ## The `/review` Skill
 

--- a/docs/landing-page-update-prompt.md
+++ b/docs/landing-page-update-prompt.md
@@ -28,6 +28,15 @@ This is the headline new capability. `diffprism server` starts a persistent proc
 
 This enables the core vision: developers using git worktrees to run multiple agents in parallel, with DiffPrism as the unified review layer.
 
+### New: Quick Actions — Approve & Commit from the Review UI (v0.24.0)
+The ⋮ dropdown menu in the file browser header lets users **Approve & Commit** or **Approve, Commit & PR** directly from the review UI. The decision is returned to the agent with a `postReviewAction` field, and the agent executes the action immediately — no extra confirmation step. This closes the loop between review and commit in a single click.
+
+### New: Desktop Notifications (v0.23.0)
+When using the global server, users get **native desktop notifications** when a new review session arrives while the DiffPrism tab is backgrounded. A bell toggle in the session list header controls notifications, with preference persisted in localStorage. Clicking a notification focuses the tab and selects the session.
+
+### New: Dismiss Reviews (v0.22.0)
+A **Dismiss** button lets users close a review without approving or requesting changes — useful when the agent is still working, the review was triggered by mistake, or no feedback is needed. Dismiss unblocks MCP polling so the agent isn't left hanging.
+
 ### Other New Features
 - **Split (side-by-side) diff view** — Toggle between unified and split views
 - **Dark/light mode toggle** — Was dark-only, now has a toggle with theme persistence
@@ -36,7 +45,7 @@ This enables the core vision: developers using git worktrees to run multiple age
 - **Agent reasoning panel** — Collapsible panel showing why the agent made changes
 - **Global setup** — `diffprism setup --global` configures at `~/.claude/` paths, no git repo required. Auto-runs on `diffprism server` start.
 - **Teardown command** — `diffprism teardown` cleanly reverses all setup changes (MCP config, hooks, skill, gitignore)
-- **v0.21.0 is current version**
+- **v0.24.1 is current version**
 
 ## Current Landing Page Structure
 
@@ -69,10 +78,12 @@ The Why page (`/why`) and Blog page (`/blog`) exist as separate routes.
 - The current Terminal → Claude Code → Browser diagram is still valid for watch mode but doesn't tell the multi-session story
 
 ### Features Grid
-- Add **Multi-session dashboard** as a feature card — session list with status badges, branch info, change stats, click to switch between reviews
+- Add **Multi-session dashboard** as a feature card — session list with status badges, branch info, change stats, click to switch between reviews, desktop notifications when reviews arrive
 - Add **Split diff view** as a feature or mention within the existing diff viewer card
 - Update existing cards if needed (e.g., the Watch Mode card could mention it's one of three modes)
 - Consider adding **Keyboard navigation** as a feature card (j/k files, s status, ? help)
+- Add or mention **Quick actions** — Approve & Commit or Approve, Commit & PR directly from the review UI, closing the review→commit loop
+- Add or mention **Dismiss** — clean exit for reviews that aren't needed, prevents agents from hanging
 
 ### How It Works
 - Keep the 3-step simplicity but update step 2 to acknowledge the modes:
@@ -115,10 +126,11 @@ diffprism teardown            # Clean removal
 - Agent reasoning display panel
 - Dark/light mode toggle
 - Keyboard shortcuts (j/k files, s status, ? hotkey guide)
-- Three-way decisions (approve, request changes, approve with comments)
-- Structured JSON results returned to agent
-- Multi-session dashboard with status badges, branch info, file counts
+- Four review decisions: approve, request changes, approve with comments, dismiss
+- Quick action menu: Approve & Commit, Approve Commit & PR (executes post-review action without extra confirmation)
+- Structured JSON results returned to agent (includes optional `postReviewAction` field)
+- Multi-session dashboard with status badges, branch info, file counts, desktop notifications for new sessions
 - MCP tools: open_review, update_review_context, get_review_result
-- CLI: review, watch, serve, setup, server, teardown
+- CLI: review, watch, serve, setup, server, teardown, start
 - Zero-config: `npx diffprism setup` handles everything
 - Global setup: `diffprism setup --global` for no-repo-required config

--- a/docs/ux-design-notes.md
+++ b/docs/ux-design-notes.md
@@ -14,17 +14,19 @@ Living document capturing user experience observations, design decisions, and ex
 
 ## Review UI
 
-### Current state (v0.21.0)
+### Current state (v0.24.1)
 - Dark/light mode toggle with theme persistence (v0.9.0)
 - Unified + split (side-by-side) diff view toggle (v0.6.0)
 - Syntax highlighting via refractor v4
-- Three review decisions: Approve / Request Changes / Approve with Comments
+- Four review decisions: Approve / Request Changes / Approve with Comments / Dismiss (v0.22.0)
+- Quick action menu (⋮): Approve & Commit, Approve Commit & PR — returns `postReviewAction` to agent (v0.24.0)
 - Inline line-level commenting — click any line to add a comment (v0.8.0)
 - Comment types: must_fix, suggestion, question, nitpick (v0.8.0)
 - File-level status tracking: unreviewed, reviewed, approved, needs_changes (v0.7.0)
 - Keyboard shortcuts: j/k navigate files, s cycles file status, ? opens hotkey guide (v0.2.12)
 - Agent reasoning display in collapsible context panel (v0.5.0)
 - Review briefing bar: complexity scoring, test coverage gaps, pattern flags (v0.3.0+)
+- Desktop notifications for new review sessions in global server mode (v0.23.0)
 
 ### Observations
 - (Add observations here as they arise from real usage)
@@ -98,6 +100,50 @@ Added `diffprism server` — a persistent global server that accepts reviews fro
 ### WS Protocol Additions
 - Server → Client: `session:list` (all sessions), `session:added` (new session notification)
 - Client → Server: `session:select` (user clicks a session)
+
+## Dismiss Reviews (v0.22.0)
+
+### Decision
+Added a Dismiss button to the review action bar. Users can close a review without approving or requesting changes.
+
+### Rationale
+Edge cases where users need to close a review without providing feedback (agent still working, review triggered by mistake, no feedback needed) left MCP polling hanging for up to 10 minutes. Dismiss provides a clean exit path that stores a result and unblocks MCP.
+
+### UX Behavior
+- "Dismiss" button appears after "Approve with Comments" in the action bar (neutral gray)
+- Session list X button also stores a dismiss result so MCP doesn't hang
+- `ReviewDecision` type now includes `"dismissed"`
+
+---
+
+## Desktop Notifications (v0.23.0)
+
+### Decision
+Added Web Notifications API support for the global server UI. When a new review session arrives while the DiffPrism tab is backgrounded, users get a native desktop notification.
+
+### UX Behavior
+- Bell toggle in the session list header enables/disables notifications
+- Preference persisted in localStorage
+- Clicking a notification focuses the tab and selects the session
+- Only fires when the tab is not visible (uses Page Visibility API)
+
+---
+
+## Quick Actions — Approve & Commit (v0.24.0)
+
+### Decision
+Added a ⋮ dropdown menu in the file browser header with two quick actions: **Approve & Commit** and **Approve, Commit & PR**.
+
+### Rationale
+The review→commit flow required the user to approve in the review UI, then tell the agent to commit. Quick actions close this loop in a single click — the `postReviewAction` field is returned to the agent, which executes immediately without asking for confirmation (v0.24.1).
+
+### UX Behavior
+- ⋮ menu in file browser header, two items
+- Submits the review with `decision: "approved"` and the selected `postReviewAction`
+- `PostReviewAction` type: `"commit"` or `"commit_and_pr"`
+- Backwards compatible — `postReviewAction` is optional on `ReviewResult`
+
+---
 
 ## Multi-Agent / Worktree Support (Remaining)
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -137,3 +137,5 @@ When `/review` is invoked, the system checks in order:
 | Global process | None | None | `diffprism server` |
 | Live diff updates | No | Yes (polls 1s) | No (per `open_review` call) |
 | After submit | Tab auto-closes | Resumes watching | Returns to session list |
+| Desktop notifications | No | No | Yes (v0.23.0) |
+| Quick actions (commit/PR) | Yes | Yes | Yes |


### PR DESCRIPTION
## What changed

Updated all documentation files to reflect features shipped in v0.22.0–v0.24.1:

- **README.md** — Added dismiss decision, quick actions, desktop notifications, `postReviewAction` field
- **docs/claude-setup.md** — Added `dismissed` to decision list, `postReviewAction` to ReviewResult docs
- **docs/workflows.md** — Added desktop notifications and quick actions rows to comparison table
- **docs/ux-design-notes.md** — Bumped current state to v0.24.1, added sections for dismiss, notifications, and quick actions
- **docs/landing-page-update-prompt.md** — Added three new feature sections (quick actions, notifications, dismiss), updated feature grid and reference feature set, bumped version to v0.24.1

## Why

Ten releases shipped today (v0.21.0–v0.24.1) with significant new features that weren't reflected in documentation. The landing page prompt was still referencing v0.21.0.

## Testing
- `pnpm test` — docs only, no code changes
- All changes are documentation updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)