### PR TITLE
minor: consolidate review modes with shared DiffPoller and universal ref selection

### DIFF
--- a/packages/core/src/__tests__/pipeline.test.ts
+++ b/packages/core/src/__tests__/pipeline.test.ts
@@ -23,14 +23,46 @@ vi.mock("../review-manager.js", () => ({
 }));
 
 const mockSendInit = vi.fn();
+const mockStoreInitPayload = vi.fn();
+const mockSendDiffUpdate = vi.fn();
+const mockSendContextUpdate = vi.fn();
+const mockSendDiffError = vi.fn();
+const mockOnSubmit = vi.fn();
 const mockWaitForResult = vi.fn();
+const mockTriggerRefresh = vi.fn();
 const mockBridgeClose = vi.fn();
-vi.mock("../ws-bridge.js", () => ({
-  createWsBridge: () => ({
-    sendInit: mockSendInit,
-    waitForResult: mockWaitForResult,
-    close: mockBridgeClose,
+vi.mock("../watch-bridge.js", () => ({
+  createWatchBridge: () =>
+    Promise.resolve({
+      port: 9999,
+      sendInit: mockSendInit,
+      storeInitPayload: mockStoreInitPayload,
+      sendDiffUpdate: mockSendDiffUpdate,
+      sendContextUpdate: mockSendContextUpdate,
+      sendDiffError: mockSendDiffError,
+      onSubmit: mockOnSubmit,
+      waitForResult: mockWaitForResult,
+      triggerRefresh: mockTriggerRefresh,
+      close: mockBridgeClose,
+    }),
+}));
+
+const mockPollerStart = vi.fn();
+const mockPollerStop = vi.fn();
+const mockPollerSetDiffRef = vi.fn();
+const mockPollerRefresh = vi.fn();
+vi.mock("../diff-poller.js", () => ({
+  createDiffPoller: () => ({
+    start: mockPollerStart,
+    stop: mockPollerStop,
+    setDiffRef: mockPollerSetDiffRef,
+    refresh: mockPollerRefresh,
   }),
+}));
+
+vi.mock("../watch-file.js", () => ({
+  writeWatchFile: vi.fn(),
+  removeWatchFile: vi.fn(),
 }));
 
 vi.mock("get-port", () => ({

--- a/packages/core/src/diff-poller.ts
+++ b/packages/core/src/diff-poller.ts
@@ -1,0 +1,103 @@
+import { getDiff } from "@diffprism/git";
+import { analyze } from "@diffprism/analysis";
+
+import type { DiffSet, DiffUpdatePayload, ReviewInitPayload, ReviewMetadata } from "./types.js";
+import { hashDiff, detectChangedFiles } from "./diff-utils.js";
+
+export interface DiffPollerOptions {
+  diffRef: string;
+  cwd: string;
+  pollInterval: number;
+  onDiffChanged: (payload: DiffUpdatePayload) => void;
+  onError?: (error: Error) => void;
+  silent?: boolean;
+}
+
+export interface DiffPoller {
+  start: () => void;
+  stop: () => void;
+  setDiffRef: (newRef: string) => void;
+  refresh: () => void;
+}
+
+export function createDiffPoller(options: DiffPollerOptions): DiffPoller {
+  let { diffRef } = options;
+  const { cwd, pollInterval, onDiffChanged, onError, silent } = options;
+
+  let lastDiffHash: string | null = null;
+  let lastDiffSet: DiffSet | null = null;
+  let refreshRequested = false;
+  let interval: ReturnType<typeof setInterval> | null = null;
+  let running = false;
+
+  function poll(): void {
+    if (!running) return;
+
+    try {
+      const { diffSet: newDiffSet, rawDiff: newRawDiff } = getDiff(diffRef, { cwd });
+      const newHash = hashDiff(newRawDiff);
+
+      if (newHash !== lastDiffHash || refreshRequested) {
+        refreshRequested = false;
+
+        const newBriefing = analyze(newDiffSet);
+        const changedFiles = detectChangedFiles(lastDiffSet, newDiffSet);
+
+        lastDiffHash = newHash;
+        lastDiffSet = newDiffSet;
+
+        const updatePayload: DiffUpdatePayload = {
+          diffSet: newDiffSet,
+          rawDiff: newRawDiff,
+          briefing: newBriefing,
+          changedFiles,
+          timestamp: Date.now(),
+        };
+
+        onDiffChanged(updatePayload);
+      }
+    } catch (err) {
+      // getDiff can fail if git state is mid-operation — silently skip by default
+      if (onError && err instanceof Error) {
+        onError(err);
+      }
+    }
+  }
+
+  return {
+    start() {
+      if (running) return;
+      running = true;
+
+      // Initialize hash from first poll without triggering onDiffChanged
+      try {
+        const { diffSet: initialDiffSet, rawDiff: initialRawDiff } = getDiff(diffRef, { cwd });
+        lastDiffHash = hashDiff(initialRawDiff);
+        lastDiffSet = initialDiffSet;
+      } catch {
+        // Will catch on next poll
+      }
+
+      interval = setInterval(poll, pollInterval);
+    },
+
+    stop() {
+      running = false;
+      if (interval) {
+        clearInterval(interval);
+        interval = null;
+      }
+    },
+
+    setDiffRef(newRef: string) {
+      diffRef = newRef;
+      // Reset hash to force next poll to detect a change
+      lastDiffHash = null;
+      lastDiffSet = null;
+    },
+
+    refresh() {
+      refreshRequested = true;
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export type {
   WatchHandle,
   DiffUpdatePayload,
   ContextUpdatePayload,
+  DiffErrorPayload,
   WatchFileInfo,
   FileReviewStatus,
   ReviewResultFile,
@@ -36,6 +37,8 @@ export type {
 
 export { startReview } from "./pipeline.js";
 export { startWatch } from "./watch.js";
+export { createDiffPoller } from "./diff-poller.js";
+export type { DiffPoller, DiffPollerOptions } from "./diff-poller.js";
 export { hashDiff, detectChangedFiles, fileKey } from "./diff-utils.js";
 export { readWatchFile, readReviewResult, consumeReviewResult } from "./watch-file.js";
 export { startGlobalServer } from "./global-server.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -154,9 +154,14 @@ export interface ReviewMetadata {
   currentBranch?: string;
 }
 
+export interface DiffErrorPayload {
+  error: string;
+}
+
 export type ServerMessage =
   | { type: "review:init"; payload: ReviewInitPayload }
   | { type: "diff:update"; payload: DiffUpdatePayload }
+  | { type: "diff:error"; payload: DiffErrorPayload }
   | { type: "context:update"; payload: ContextUpdatePayload }
   | { type: "session:list"; payload: SessionSummary[] }
   | { type: "session:added"; payload: SessionSummary }
@@ -165,6 +170,7 @@ export type ServerMessage =
 
 export type ClientMessage =
   | { type: "review:submit"; payload: ReviewResult }
+  | { type: "diff:change_ref"; payload: { diffRef: string } }
   | { type: "session:select"; payload: { sessionId: string } }
   | { type: "session:close"; payload: { sessionId: string } };
 

--- a/packages/ui/src/components/BriefingBar/BriefingBar.tsx
+++ b/packages/ui/src/components/BriefingBar/BriefingBar.tsx
@@ -10,14 +10,13 @@ import {
   Gauge,
   ShieldAlert,
   Search,
-  GitBranch,
 } from "lucide-react";
 import { useReviewStore } from "../../store/review";
 import { RefSelector } from "../RefSelector";
 
 export function BriefingBar() {
   const [expanded, setExpanded] = useState(false);
-  const { briefing, metadata, isServerMode, clearReview } = useReviewStore();
+  const { briefing, isServerMode, clearReview } = useReviewStore();
 
   if (!briefing) return null;
   
@@ -57,13 +56,6 @@ export function BriefingBar() {
             <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-red-100 dark:bg-red-600/20 text-red-700 dark:text-red-400 border border-red-300 dark:border-red-500/30 font-semibold">
               <ShieldAlert className="w-3 h-3" />
               {securityFlags.length} security flag{securityFlags.length !== 1 ? "s" : ""}
-            </span>
-          )}
-
-          {metadata?.currentBranch && !isServerMode && (
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-gray-100 dark:bg-gray-600/20 text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-500/30 font-mono">
-              <GitBranch className="w-3 h-3" />
-              {metadata.currentBranch}
             </span>
           )}
 
@@ -117,11 +109,9 @@ export function BriefingBar() {
           )}
         </div>
       </button>
-      {isServerMode && (
-        <div className="px-3 py-2.5 border-l border-border flex-shrink-0">
-          <RefSelector />
-        </div>
-      )}
+      <div className="px-3 py-2.5 border-l border-border flex-shrink-0">
+        <RefSelector />
+      </div>
       </div>
 
       {/* Expanded details */}

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -61,6 +61,8 @@ export function useWebSocket(options?: UseWebSocketOptions) {
           initReview(message.payload);
         } else if (message.type === "diff:update") {
           updateDiff(message.payload);
+        } else if (message.type === "diff:error") {
+          console.error("Diff error:", message.payload.error);
         } else if (message.type === "context:update") {
           updateContext(message.payload);
         } else if (message.type === "session:list") {

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -206,9 +206,14 @@ export interface SessionSummary {
   hasNewChanges?: boolean;
 }
 
+export interface DiffErrorPayload {
+  error: string;
+}
+
 export type ServerMessage =
   | { type: "review:init"; payload: ReviewInitPayload }
   | { type: "diff:update"; payload: DiffUpdatePayload }
+  | { type: "diff:error"; payload: DiffErrorPayload }
   | { type: "context:update"; payload: ContextUpdatePayload }
   | { type: "session:list"; payload: SessionSummary[] }
   | { type: "session:added"; payload: SessionSummary }
@@ -217,5 +222,6 @@ export type ServerMessage =
 
 export type ClientMessage =
   | { type: "review:submit"; payload: ReviewResult }
+  | { type: "diff:change_ref"; payload: { diffRef: string } }
   | { type: "session:select"; payload: { sessionId: string } }
   | { type: "session:close"; payload: { sessionId: string } };


### PR DESCRIPTION
## Summary
- Extract `DiffPoller` abstraction (`packages/core/src/diff-poller.ts`) that unifies polling logic previously duplicated across ephemeral, watch, and server modes (~120 lines eliminated)
- Add `/api/refs` and `/api/compare` HTTP routes to `WatchBridge`, enabling the `RefSelector` UI component in ephemeral and watch modes (previously server-only)
- Pass `httpPort` in browser URL for all modes so the UI's `useHttpApi` hook activates universally
- Remove `isServerMode` gate from `BriefingBar` — `RefSelector` now renders in all review modes
- Sync UI types with core (`DiffErrorPayload`, `diff:error`, `diff:change_ref`)

## Why
Feature parity across review modes. Previously, ephemeral mode had no live polling and no ref selection; watch mode had polling but no ref selection. Now all modes share the same capabilities, providing a consistent review experience regardless of how the review was started.

## Testing
- `pnpm test` — all tests pass (258 total across core/git/analysis/cli/ui)
- `npx tsc --noEmit -p packages/core/tsconfig.json` — clean
- Manual: `pnpm cli review --staged` — RefSelector appears and is interactive
- Manual: `pnpm cli watch` — RefSelector works + live polling continues after ref change
- Manual: `pnpm cli server` — no regression in server mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)