### PR TITLE
minor: annotation MCP tools, triage UI, annotation rendering

### DIFF
--- a/ROADMAP-TASKS.md
+++ b/ROADMAP-TASKS.md
@@ -3,7 +3,7 @@
 > This document tracks implementation progress toward the new vision. Update checkboxes as work is completed. Each session should read this file to understand what's done and what's next.
 
 **Last updated:** 2026-02-26
-**Current version:** v0.28.0
+**Current version:** v0.30.0
 **Branch for plan docs:** `new-maps`
 
 ---
@@ -20,7 +20,7 @@
 
 *The analysis engine exists. These tasks expose it headlessly so agents can self-review. This is wiring, not building.*
 
-- [ ] **1.1 `get_diff` MCP tool**
+- [x] **1.1 `get_diff` MCP tool** *(shipped v0.29.0, PR #128)*
   - Add tool handler in `packages/mcp-server/src/index.ts`
   - Accepts `diff_ref` parameter (same values as `open_review`: "staged", "unstaged", "working-copy", or ref range)
   - Calls `getDiff()` from `@diffprism/git`, returns `DiffSet` as JSON
@@ -28,7 +28,7 @@
   - Files: `packages/mcp-server/src/index.ts`
   - Verify: agent can call `get_diff({ diff_ref: "unstaged" })` and receive structured DiffSet
 
-- [ ] **1.2 `analyze_diff` MCP tool**
+- [x] **1.2 `analyze_diff` MCP tool** *(shipped v0.29.0, PR #128)*
   - Add tool handler in `packages/mcp-server/src/index.ts`
   - Accepts `diff_ref` parameter
   - Calls `getDiff()` → `analyze()`, returns `ReviewBriefing` as JSON
@@ -36,7 +36,7 @@
   - Files: `packages/mcp-server/src/index.ts`
   - Verify: agent can call `analyze_diff({ diff_ref: "unstaged" })` and receive ReviewBriefing with complexity scores, test gaps, pattern flags
 
-- [ ] **1.3 Update `/review` skill + docs for self-review pattern**
+- [x] **1.3 Update `/review` skill + docs for self-review pattern** *(shipped v0.29.0, PR #128)*
   - Update `cli/src/templates/skill.ts` to document the self-review loop:
     ```
     Agent writes code
@@ -48,7 +48,7 @@
   - Update `docs/workflows.md` with Posture 2 workflow section
   - Files: `cli/src/templates/skill.ts`, `docs/workflows.md`
 
-- [ ] **1.4 Update `diffprism setup` to auto-approve new tools**
+- [x] **1.4 Update `diffprism setup` to auto-approve new tools** *(shipped v0.29.0, PR #128)*
   - Add `get_diff` and `analyze_diff` to the auto-approve tool list
   - Files: `cli/src/commands/setup.ts`
   - Verify: `diffprism setup` includes new tools in `.claude/settings.json`
@@ -61,7 +61,7 @@
 
 *The triage system currently puts everything in "notable." Real categorization makes both human review and agent self-review more useful.*
 
-- [ ] **2.1 Implement real file categorization**
+- [x] **2.1 Implement real file categorization** *(shipped v0.30.0, PR #129)*
   - Update `categorizeFiles()` in `packages/analysis/src/deterministic.ts`
   - Critical: files with security patterns, breaking API changes, high complexity (score >= 8)
   - Mechanical: pure renames, formatting-only changes, import-only changes, config-only
@@ -85,13 +85,13 @@
 
 *Unlocks "agent as reviewer" — specialized agents can post structured findings to review sessions.*
 
-- [ ] **3.1 Add annotation types to core**
+- [x] **3.1 Add annotation types to core** *(shipped v0.30.0, PR #129)*
   - New interfaces in `packages/core/src/types.ts`:
     - `Annotation`: file, line, body, type (finding/suggestion/question/warning), confidence (0-1), category (security/performance/convention/etc), sourceAgent
     - `SessionState`: files, comments, annotations, per-file status
   - Mirror types in `packages/ui/src/types.ts`
 
-- [ ] **3.2 Add annotation API to global server**
+- [x] **3.2 Add annotation API to global server** *(shipped v0.30.0, PR #129)*
   - `POST /api/reviews/:id/annotations` — agent posts findings
   - `GET /api/reviews/:id/state` — returns full session state
   - WebSocket: `annotation:added` event pushes to connected UI clients
@@ -139,12 +139,12 @@
 
 ## Phase 5: Platform Foundations (Track C)
 
-- [ ] **5.1 Worktree detection & metadata (#45)**
+- [x] **5.1 Worktree detection & metadata (#45)** *(shipped v0.30.0, PR #129)*
   - Detect if running in a git worktree, extract branch/path info
   - Surface in session metadata for multi-agent context
   - Files: `packages/git/src/local.ts`, `packages/core/src/types.ts`
 
-- [ ] **5.2 Review history persistence**
+- [x] **5.2 Review history persistence** *(shipped v0.30.0, PR #129)*
   - Store review decisions per-repo (local JSON in `.diffprism/history/`)
   - Record: timestamp, decision, files reviewed, comments made, ref
   - Foundation for convention learning later
@@ -186,8 +186,8 @@
 
 These need answers before or during implementation. Record decisions here as they're made.
 
-1. **Headless tool output verbosity** — Should `analyze_diff` return the full `ReviewBriefing` or a condensed summary? → _Decision: TBD_
-2. **Self-review loop integration** — Built into `/review` skill automatically, or pattern agents discover via docs? → _Decision: TBD_
+1. **Headless tool output verbosity** — Should `analyze_diff` return the full `ReviewBriefing` or a condensed summary? → _Decision: Full ReviewBriefing JSON (shipped v0.29.0)_
+2. **Self-review loop integration** — Built into `/review` skill automatically, or pattern agents discover via docs? → _Decision: Documented in skill template + workflows.md (shipped v0.29.0)_
 3. **Annotation persistence** — Do agent annotations persist across sessions or are they per-review? → _Decision: TBD_
 4. **Multi-agent annotation conflicts** — When two agents annotate the same line, stack or merge? → _Decision: TBD_
 5. **Verification command sandboxing** — How to safely run tests/lint in the repo from the review UI? → _Decision: TBD_
@@ -201,3 +201,6 @@ Record what was accomplished each session to maintain context.
 | Date | Session | What was done |
 |------|---------|---------------|
 | 2026-02-26 | Planning | Analyzed product plan, technical plan, and CLAUDE.md. Created this task tracker. Identified Phase 1 (headless tools) as immediate priority. |
+| 2026-02-26 | Phase 1 | Shipped headless `get_diff` + `analyze_diff` MCP tools, updated setup/teardown, skill docs, workflows. PR #128 → v0.29.0. |
+| 2026-02-26 | Phase 2-5 parallel | 5 worktree agents: real file triage (2.1), annotation types (3.1), annotation API (3.2), worktree detection (5.1), review history (5.2). Merged + fixed CI. PR #129 → v0.30.0. |
+| 2026-02-26 | Phase 3-5 parallel | Launching 5 agents: add_annotation MCP (3.3), get_review_state MCP (3.4), triage UI (2.2), annotation rendering (3.5), flag_for_attention (5.3). |

--- a/cli/src/__tests__/setup.test.ts
+++ b/cli/src/__tests__/setup.test.ts
@@ -377,6 +377,9 @@ describe("setup command", () => {
                 "mcp__diffprism__get_review_result",
                 "mcp__diffprism__get_diff",
                 "mcp__diffprism__analyze_diff",
+                "mcp__diffprism__add_annotation",
+                "mcp__diffprism__get_review_state",
+                "mcp__diffprism__flag_for_attention",
               ],
             },
             hooks: {
@@ -407,6 +410,9 @@ describe("setup command", () => {
         "mcp__diffprism__get_review_result",
         "mcp__diffprism__get_diff",
         "mcp__diffprism__analyze_diff",
+        "mcp__diffprism__add_annotation",
+        "mcp__diffprism__get_review_state",
+        "mcp__diffprism__flag_for_attention",
       ]);
     });
   });
@@ -757,6 +763,9 @@ describe("setup command", () => {
                 "mcp__diffprism__get_review_result",
                 "mcp__diffprism__get_diff",
                 "mcp__diffprism__analyze_diff",
+                "mcp__diffprism__add_annotation",
+                "mcp__diffprism__get_review_state",
+                "mcp__diffprism__flag_for_attention",
               ],
             },
           });

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -100,6 +100,9 @@ function setupClaudeSettings(
     "mcp__diffprism__get_review_result",
     "mcp__diffprism__get_diff",
     "mcp__diffprism__analyze_diff",
+    "mcp__diffprism__add_annotation",
+    "mcp__diffprism__get_review_state",
+    "mcp__diffprism__flag_for_attention",
   ];
 
   const allPresent = toolNames.every((t) => allow.includes(t));
@@ -416,6 +419,9 @@ export function isGlobalSetupDone(): boolean {
     "mcp__diffprism__get_review_result",
     "mcp__diffprism__get_diff",
     "mcp__diffprism__analyze_diff",
+    "mcp__diffprism__add_annotation",
+    "mcp__diffprism__get_review_state",
+    "mcp__diffprism__flag_for_attention",
   ];
 
   return toolNames.every((t) => allow.includes(t));

--- a/cli/src/commands/teardown.ts
+++ b/cli/src/commands/teardown.ts
@@ -63,6 +63,9 @@ function teardownClaudePermissions(
     "mcp__diffprism__get_review_result",
     "mcp__diffprism__get_diff",
     "mcp__diffprism__analyze_diff",
+    "mcp__diffprism__add_annotation",
+    "mcp__diffprism__get_review_state",
+    "mcp__diffprism__flag_for_attention",
   ];
 
   const filtered = allow.filter((t) => !toolNames.includes(t));

--- a/packages/mcp-server/src/__tests__/mcp-server.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-server.test.ts
@@ -96,12 +96,15 @@ describe("mcp-server", () => {
     const { startMcpServer } = await import("../index.js");
     await startMcpServer();
 
-    expect(mockToolFn).toHaveBeenCalledTimes(5);
+    expect(mockToolFn).toHaveBeenCalledTimes(8);
     expect(mockToolFn.mock.calls[0][0]).toBe("open_review");
     expect(mockToolFn.mock.calls[1][0]).toBe("update_review_context");
     expect(mockToolFn.mock.calls[2][0]).toBe("get_review_result");
     expect(mockToolFn.mock.calls[3][0]).toBe("get_diff");
     expect(mockToolFn.mock.calls[4][0]).toBe("analyze_diff");
+    expect(mockToolFn.mock.calls[5][0]).toBe("add_annotation");
+    expect(mockToolFn.mock.calls[6][0]).toBe("get_review_state");
+    expect(mockToolFn.mock.calls[7][0]).toBe("flag_for_attention");
   });
 
   it("connects the stdio transport", async () => {

--- a/packages/ui/src/components/AnnotationPanel/AnnotationPanel.tsx
+++ b/packages/ui/src/components/AnnotationPanel/AnnotationPanel.tsx
@@ -1,0 +1,150 @@
+import { useState, useMemo } from "react";
+import {
+  AlertTriangle,
+  Lightbulb,
+  HelpCircle,
+  AlertCircle,
+  X,
+  Eye,
+  EyeOff,
+  Bot,
+} from "lucide-react";
+import type { Annotation } from "../../types";
+
+const CATEGORY_COLORS: Record<string, string> = {
+  security: "text-red-500 dark:text-red-400",
+  performance: "text-orange-500 dark:text-orange-400",
+  convention: "text-blue-500 dark:text-blue-400",
+  correctness: "text-yellow-500 dark:text-yellow-400",
+  complexity: "text-purple-500 dark:text-purple-400",
+  "test-coverage": "text-cyan-500 dark:text-cyan-400",
+  documentation: "text-gray-500 dark:text-gray-400",
+  other: "text-gray-500 dark:text-gray-400",
+};
+
+const TYPE_ICONS: Record<string, typeof AlertTriangle> = {
+  finding: AlertCircle,
+  suggestion: Lightbulb,
+  question: HelpCircle,
+  warning: AlertTriangle,
+};
+
+interface AnnotationPanelProps {
+  annotations: Annotation[];
+  onDismiss: (annotationId: string) => void;
+  onNavigate: (file: string) => void;
+}
+
+export function AnnotationPanel({
+  annotations,
+  onDismiss,
+  onNavigate,
+}: AnnotationPanelProps) {
+  const [showDismissed, setShowDismissed] = useState(false);
+
+  const grouped = useMemo(() => {
+    const filtered = showDismissed
+      ? annotations
+      : annotations.filter((a) => !a.dismissed);
+
+    const groups = new Map<string, Annotation[]>();
+    for (const a of filtered) {
+      const agent = a.source.agent;
+      if (!groups.has(agent)) groups.set(agent, []);
+      groups.get(agent)!.push(a);
+    }
+    return groups;
+  }, [annotations, showDismissed]);
+
+  const activeCount = annotations.filter((a) => !a.dismissed).length;
+
+  if (annotations.length === 0) return null;
+
+  return (
+    <div className="border-t border-border">
+      <div className="px-4 py-2 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Bot className="w-4 h-4 text-text-secondary" />
+          <span className="text-xs font-semibold text-text-secondary uppercase tracking-wide">
+            Agent Annotations ({activeCount})
+          </span>
+        </div>
+        {annotations.some((a) => a.dismissed) && (
+          <button
+            onClick={() => setShowDismissed(!showDismissed)}
+            className="flex items-center gap-1 text-xs text-text-secondary hover:text-text-primary cursor-pointer"
+          >
+            {showDismissed ? (
+              <EyeOff className="w-3 h-3" />
+            ) : (
+              <Eye className="w-3 h-3" />
+            )}
+            {showDismissed ? "Hide dismissed" : "Show dismissed"}
+          </button>
+        )}
+      </div>
+
+      <div className="max-h-64 overflow-y-auto">
+        {Array.from(grouped.entries()).map(([agent, agentAnnotations]) => (
+          <div key={agent} className="border-t border-border/50">
+            <div className="px-4 py-1.5 flex items-center gap-2">
+              <span className="text-xs font-medium text-accent">{agent}</span>
+              <span className="text-xs text-text-secondary">
+                ({agentAnnotations.length})
+              </span>
+            </div>
+
+            {agentAnnotations.map((annotation) => {
+              const Icon = TYPE_ICONS[annotation.type] ?? AlertCircle;
+              const colorClass =
+                CATEGORY_COLORS[annotation.category] ?? CATEGORY_COLORS.other;
+
+              return (
+                <div
+                  key={annotation.id}
+                  className={`px-4 py-2 flex items-start gap-2 hover:bg-text-primary/5 cursor-pointer group ${
+                    annotation.dismissed ? "opacity-40" : ""
+                  }`}
+                  onClick={() => onNavigate(annotation.file)}
+                >
+                  <Icon
+                    className={`w-3.5 h-3.5 mt-0.5 flex-shrink-0 ${colorClass}`}
+                  />
+
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-0.5">
+                      <span className="text-xs text-text-secondary font-mono truncate">
+                        {annotation.file}:{annotation.line}
+                      </span>
+                      <span
+                        className={`text-[10px] font-semibold uppercase ${colorClass}`}
+                      >
+                        {annotation.category}
+                      </span>
+                    </div>
+                    <p className="text-xs text-text-primary truncate">
+                      {annotation.body}
+                    </p>
+                  </div>
+
+                  {!annotation.dismissed && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDismiss(annotation.id);
+                      }}
+                      className="p-0.5 rounded hover:bg-text-primary/10 text-text-secondary opacity-0 group-hover:opacity-100 cursor-pointer flex-shrink-0"
+                      title="Dismiss"
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/AnnotationPanel/index.ts
+++ b/packages/ui/src/components/AnnotationPanel/index.ts
@@ -1,0 +1,1 @@
+export { AnnotationPanel } from "./AnnotationPanel.js";

--- a/packages/ui/src/components/ReviewView.tsx
+++ b/packages/ui/src/components/ReviewView.tsx
@@ -4,6 +4,8 @@ import { FileBrowser } from "./FileBrowser";
 import { DiffViewer } from "./DiffViewer";
 import { ActionBar } from "./ActionBar";
 import { HotkeyGuide } from "./HotkeyGuide";
+import { AnnotationPanel } from "./AnnotationPanel";
+import { useReviewStore } from "../store/review";
 import type { ReviewResult } from "../types";
 
 interface ReviewViewProps {
@@ -15,14 +17,23 @@ interface ReviewViewProps {
 }
 
 export function ReviewView({ onSubmit, onDismiss, isWatchMode, watchSubmitted, hasUnreviewedChanges }: ReviewViewProps) {
+  const { annotations, dismissAnnotation, selectFile } = useReviewStore();
+
   return (
     <div className="h-screen flex flex-col bg-background">
       <BriefingBar />
       <ReasoningPanel />
       <div className="flex flex-1 min-h-0">
-        {/* Left sidebar — File Browser */}
-        <div className="w-[280px] flex-shrink-0">
-          <FileBrowser onSubmit={onSubmit} />
+        {/* Left sidebar — File Browser + Annotations */}
+        <div className="w-[280px] flex-shrink-0 flex flex-col">
+          <div className="flex-1 min-h-0">
+            <FileBrowser onSubmit={onSubmit} />
+          </div>
+          <AnnotationPanel
+            annotations={annotations}
+            onDismiss={dismissAnnotation}
+            onNavigate={selectFile}
+          />
         </div>
 
         {/* Main area — Diff Viewer */}

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -22,6 +22,8 @@ export function useWebSocket(options?: UseWebSocketOptions) {
     addSession,
     updateSession,
     removeSession,
+    addAnnotation,
+    dismissAnnotation,
   } = useReviewStore();
 
   useEffect(() => {
@@ -74,6 +76,10 @@ export function useWebSocket(options?: UseWebSocketOptions) {
           updateSession(message.payload);
         } else if (message.type === "session:removed") {
           removeSession(message.payload.sessionId);
+        } else if (message.type === "annotation:added") {
+          addAnnotation(message.payload);
+        } else if (message.type === "annotation:dismissed") {
+          dismissAnnotation(message.payload.annotationId);
         }
       } catch (err) {
         console.error("Failed to parse WebSocket message:", err);
@@ -92,7 +98,7 @@ export function useWebSocket(options?: UseWebSocketOptions) {
       ws.close();
       wsRef.current = null;
     };
-  }, [setConnectionStatus, initReview, updateDiff, updateContext, setServerMode, setSessions, addSession, updateSession, removeSession]);
+  }, [setConnectionStatus, initReview, updateDiff, updateContext, setServerMode, setSessions, addSession, updateSession, removeSession, addAnnotation, dismissAnnotation]);
 
   const sendResult = useCallback((result: ReviewResult) => {
     const ws = wsRef.current;

--- a/packages/ui/src/store/review.ts
+++ b/packages/ui/src/store/review.ts
@@ -9,6 +9,7 @@ import type {
   DiffUpdatePayload,
   ContextUpdatePayload,
   SessionSummary,
+  Annotation,
 } from "../types";
 import { getFileKey } from "../lib/file-key";
 
@@ -45,6 +46,9 @@ export interface ReviewState {
   // Compare ref (dynamic ref selector)
   compareRef: string | null;
 
+  // Annotations
+  annotations: Annotation[];
+
   // Server mode (multi-session)
   showHotkeyGuide: boolean;
   isServerMode: boolean;
@@ -76,6 +80,8 @@ export interface ReviewState {
   setHunkCount: (count: number) => void;
   setFocusedHunkIndex: (index: number | null) => void;
   setCompareRef: (ref: string | null) => void;
+  addAnnotation: (annotation: Annotation) => void;
+  dismissAnnotation: (annotationId: string) => void;
   selectSession: (sessionId: string) => void;
   clearReview: () => void;
 }
@@ -99,6 +105,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   focusedHunkIndex: null,
   hunkCount: 0,
   compareRef: null,
+  annotations: [],
   showHotkeyGuide: false,
   isServerMode: false,
   sessions: [],
@@ -124,6 +131,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       selectedFile: firstFile,
       fileStatuses,
       comments: [],
+      annotations: [],
       activeCommentKey: null,
       focusedHunkIndex: null,
       hunkCount: 0,
@@ -330,6 +338,18 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
     set({ compareRef: ref });
   },
 
+  addAnnotation: (annotation: Annotation) => {
+    set((state) => ({ annotations: [...state.annotations, annotation] }));
+  },
+
+  dismissAnnotation: (annotationId: string) => {
+    set((state) => ({
+      annotations: state.annotations.map((a) =>
+        a.id === annotationId ? { ...a, dismissed: true } : a,
+      ),
+    }));
+  },
+
   selectSession: (sessionId: string) => {
     set({ activeSessionId: sessionId });
   },
@@ -344,6 +364,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       selectedFile: null,
       fileStatuses: {},
       comments: [],
+      annotations: [],
       activeCommentKey: null,
       focusedHunkIndex: null,
       hunkCount: 0,


### PR DESCRIPTION
## Summary

- **`add_annotation` MCP tool** — agents POST structured findings (file, line, body, type, confidence, category) to active review sessions on the global server
- **`get_review_state` MCP tool** — agents read session summary + annotations to check review progress or read other agents' findings
- **`flag_for_attention` MCP tool** — agents batch-flag files for human attention with reasons (posts warning annotations)
- **Triage view in FileBrowser** — groups files by critical/notable/mechanical from analysis briefing, with "Approve all" button for mechanical changes
- **Annotation panel in ReviewView** — displays agent annotations grouped by source agent, with dismiss/navigate, below the file browser
- **WebSocket handlers** for `annotation:added` and `annotation:dismissed` events in the UI store + hook

## Details

### New MCP Tools (3)

| Tool | Purpose | Parameters |
|------|---------|-----------|
| `add_annotation` | Post a finding to a review session | `session_id`, `file`, `line`, `body`, `type`, `confidence?`, `category?`, `source_agent?` |
| `get_review_state` | Read session state + annotations | `session_id?` (defaults to last session) |
| `flag_for_attention` | Batch-flag files for human review | `session_id?`, `files[]` (path + reason), `source_agent?` |

All three require a running global server (`diffprism server`). Setup/teardown updated with all 3 new tool names (8 total).

### UI Changes

- **FileBrowser**: When briefing has triage data, files are grouped into Critical/Notable/Mechanical sections with collapse/expand. Mechanical section has an "Approve all" button.
- **AnnotationPanel**: New component renders annotations grouped by source agent with category colors, type icons, dismiss buttons, and click-to-navigate.
- **Store**: `annotations` state with `addAnnotation`/`dismissAnnotation` actions, reset on init/clear.
- **WebSocket hook**: Handles `annotation:added` and `annotation:dismissed` server messages.

## Testing

- `pnpm test` passes (MCP 11/11, Core 92/92, CLI 68/68, UI store 48/48)
- `pnpm run build` passes
- Pre-existing UI test failure in `notifications.test.ts` (missing `@testing-library/react` dep) — unrelated

## Release Notes

**v0.31.0 — Agent Annotation Tools + Triage UI**

Three new MCP tools let agents participate in code review: `add_annotation` posts structured findings to review sessions, `get_review_state` reads session state and annotations, and `flag_for_attention` batch-flags files for human attention. The FileBrowser now groups files by triage category (critical/notable/mechanical) with batch-approve for mechanical changes. Agent annotations appear in a new panel below the file browser, grouped by source agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)