### PR TITLE
minor: Add annotations param to open_review MCP tool

### DIFF
--- a/packages/core/src/global-server.ts
+++ b/packages/core/src/global-server.ts
@@ -765,6 +765,14 @@ export async function startGlobalServer(
           payload: session.payload,
         };
         ws.send(JSON.stringify(msg));
+
+        // Send any existing annotations
+        for (const annotation of session.annotations) {
+          ws.send(JSON.stringify({
+            type: "annotation:added",
+            payload: annotation,
+          } satisfies ServerMessage));
+        }
       }
     } else {
       // No specific session requested — send full session list (server mode UI)
@@ -787,6 +795,14 @@ export async function startGlobalServer(
             type: "review:init",
             payload: session.payload,
           } satisfies ServerMessage));
+
+          // Send any existing annotations
+          for (const annotation of session.annotations) {
+            ws.send(JSON.stringify({
+              type: "annotation:added",
+              payload: annotation,
+            } satisfies ServerMessage));
+          }
         }
       }
     }
@@ -820,6 +836,14 @@ export async function startGlobalServer(
               type: "review:init",
               payload: session.payload,
             } satisfies ServerMessage));
+
+            // Send any existing annotations
+            for (const annotation of session.annotations) {
+              ws.send(JSON.stringify({
+                type: "annotation:added",
+                payload: annotation,
+              } satisfies ServerMessage));
+            }
           }
         } else if (msg.type === "session:close") {
           const closedId = msg.payload.sessionId;


### PR DESCRIPTION
## What changed

- Added optional `annotations` array parameter to `open_review` MCP tool — agents can now pass initial annotations (findings, suggestions, questions, warnings) that appear immediately when the review UI opens
- Fixed bug in global server where annotations added between session creation and UI connection were silently lost — annotations are now sent after `review:init` on all three WS connection paths (direct sessionId, auto-select single session, session:select)

## Why

`open_review` blocks until the user submits their review, so a single agent can never call `add_annotation` after opening. This makes the multi-agent annotation workflow impractical for isolated agents. By accepting annotations upfront, any agent can attach findings to a review in a single call.

## Testing

- `pnpm test` — all 322 tests pass
- Type-check passes for both modified packages
- Manual verification: called `open_review` with annotations array, confirmed annotations appear in both the sidebar AnnotationPanel and inline in the diff viewer with gutter indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)