### PR TITLE
patch: fix GitHub PR paths, RefSelector guards, error feedback, notifications, and annotation truncation

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -7,8 +7,8 @@ import { SessionList } from "./components/SessionList";
 import type { ReviewResult } from "./types";
 
 export default function App() {
-  const { permission: notificationPermission, enabled: notificationsEnabled, toggle: toggleNotifications, notifyNewSession } = useNotifications({ onSessionSelect: handleSelectSession });
-  const { sendResult, selectSession: wsSelectSession, closeSession: wsCloseSession, connectionStatus } = useWebSocket({ onSessionAdded: notifyNewSession });
+  const { permission: notificationPermission, enabled: notificationsEnabled, toggle: toggleNotifications, notifyNewSession, notifySessionUpdated, notifyDiffUpdated, notifyAnnotationAdded } = useNotifications({ onSessionSelect: handleSelectSession });
+  const { sendResult, selectSession: wsSelectSession, closeSession: wsCloseSession, connectionStatus } = useWebSocket({ onSessionAdded: notifyNewSession, onSessionUpdated: notifySessionUpdated, onDiffUpdated: notifyDiffUpdated, onAnnotationAdded: notifyAnnotationAdded });
   const {
     diffSet,
     metadata,

--- a/packages/ui/src/components/AnnotationPanel/AnnotationPanel.tsx
+++ b/packages/ui/src/components/AnnotationPanel/AnnotationPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import {
   AlertTriangle,
   Lightbulb,
@@ -23,6 +23,40 @@ interface AnnotationPanelProps {
   annotations: Annotation[];
   onDismiss: (annotationId: string) => void;
   onNavigate: (file: string) => void;
+}
+
+function AnnotationBody({ body }: { body: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const isLong = body.length > 120 || body.includes("\n");
+
+  const toggle = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setExpanded((v) => !v);
+  }, []);
+
+  if (!isLong) {
+    return <p className="text-xs text-text-primary">{body}</p>;
+  }
+
+  if (expanded) {
+    return (
+      <div>
+        <p className="text-xs text-text-primary whitespace-pre-wrap">{body}</p>
+        <button onClick={toggle} className="text-[10px] text-accent hover:underline mt-0.5 cursor-pointer">
+          Show less
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p className="text-xs text-text-primary truncate">{body}</p>
+      <button onClick={toggle} className="text-[10px] text-accent hover:underline mt-0.5 cursor-pointer">
+        Show more
+      </button>
+    </div>
+  );
 }
 
 export function AnnotationPanel({
@@ -112,9 +146,7 @@ export function AnnotationPanel({
                         {annotation.category}
                       </span>
                     </div>
-                    <p className="text-xs text-text-primary truncate">
-                      {annotation.body}
-                    </p>
+                    <AnnotationBody body={annotation.body} />
                   </div>
 
                   {!annotation.dismissed && (

--- a/ui-dist/index.html
+++ b/ui-dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>DiffPrism</title>
-    <script type="module" crossorigin src="/assets/index-l4Jd_M6L.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-RCLz30rX.css">
+    <script type="module" crossorigin src="/assets/index-BfqEajZq.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-vG-fI3wH.css">
   </head>
   <body style="background-color: var(--color-background); margin: 0;">
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Fixed GitHub PR history writing to literal `github:owner/repo/` filesystem paths
- Disabled RefSelector for GitHub PRs where git operations aren't possible
- Added error banners in RefSelector when ref comparison fails
- Extended browser notifications to cover review submitted, diff updated, and annotation added events
- Added expand/collapse for long annotation bodies in the sidebar panel

## What changed

**GitHub PR history path (packages/core):** Added early return in `recordReviewHistory()` when `projectPath` starts with `github:`, plus server-side guards on `/refs` and `/compare` endpoints.

**RefSelector (packages/ui):** Detects `metadata.githubPr` and renders static badge instead of interactive dropdown. On comparison failure, shows inline error banner instead of silently closing.

**useHttpApi (packages/ui):** `compareAgainst` now returns `{ ok, error? }` instead of boolean, surfacing server error messages.

**Notifications (packages/ui):** Extracted `sendNotification()` helper, added `notifySessionUpdated`, `notifyDiffUpdated`, `notifyAnnotationAdded`. Wired through `useWebSocket` → `App.tsx`.

**AnnotationPanel (packages/ui):** New `AnnotationBody` component with expand/collapse for bodies over 120 chars or containing newlines.

## Testing
- `pnpm test` passes (342 tests)
- `pnpm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)