### PR TITLE
minor: add configurable workflow tips overlay

### DIFF
--- a/packages/ui/src/__tests__/store.test.ts
+++ b/packages/ui/src/__tests__/store.test.ts
@@ -70,6 +70,7 @@ describe("review store", () => {
       compareRef: null,
       focusedHunkIndex: null,
       hunkCount: 0,
+      showWorkflowTips: false,
       isServerMode: false,
       sessions: [],
       activeSessionId: null,
@@ -249,6 +250,18 @@ describe("review store", () => {
       useReviewStore.getState().toggleTheme(); // light → dark
       expect(useReviewStore.getState().theme).toBe("dark");
       expect(localStorage.getItem("diffprism-theme")).toBe("dark");
+    });
+  });
+
+  describe("toggleWorkflowTips", () => {
+    it("toggles showWorkflowTips on and off", () => {
+      expect(useReviewStore.getState().showWorkflowTips).toBe(false);
+
+      useReviewStore.getState().toggleWorkflowTips();
+      expect(useReviewStore.getState().showWorkflowTips).toBe(true);
+
+      useReviewStore.getState().toggleWorkflowTips();
+      expect(useReviewStore.getState().showWorkflowTips).toBe(false);
     });
   });
 

--- a/packages/ui/src/components/DiffViewer/DiffViewer.tsx
+++ b/packages/ui/src/components/DiffViewer/DiffViewer.tsx
@@ -12,7 +12,7 @@ import {
 import type { ChangeData, HunkData, GutterOptions, ChangeEventArgs, EventMap } from "react-diff-view";
 import { refractor } from "refractor";
 import { useReviewStore } from "../../store/review";
-import { FileCode, Columns2, Rows2, HelpCircle } from "lucide-react";
+import { FileCode, Columns2, Rows2, HelpCircle, Lightbulb } from "lucide-react";
 import { InlineCommentForm, InlineCommentThread, InlineAnnotationThread } from "../InlineComment";
 import { ThemeToggle } from "../ThemeToggle";
 import { getFileKey, getDisplayPath } from "../../lib/file-key";
@@ -175,6 +175,7 @@ export function DiffViewer() {
     deleteComment,
     setActiveCommentKey,
     toggleHotkeyGuide,
+    toggleWorkflowTips,
     focusedHunkIndex,
     setHunkCount,
     annotations,
@@ -523,6 +524,7 @@ export function DiffViewer() {
         viewMode={viewMode}
         onViewModeChange={setViewMode}
         onToggleHotkeyGuide={toggleHotkeyGuide}
+        onToggleWorkflowTips={toggleWorkflowTips}
       />
       <div ref={scrollContainerRef} className="flex-1 overflow-auto">
         <Diff
@@ -553,6 +555,7 @@ function FileHeader({
   viewMode,
   onViewModeChange,
   onToggleHotkeyGuide,
+  onToggleWorkflowTips,
 }: {
   path: string;
   stage?: "staged" | "unstaged";
@@ -561,6 +564,7 @@ function FileHeader({
   viewMode?: "unified" | "split";
   onViewModeChange?: (mode: "unified" | "split") => void;
   onToggleHotkeyGuide?: () => void;
+  onToggleWorkflowTips?: () => void;
 }) {
   return (
     <div className="flex items-center gap-3 px-4 py-2.5 bg-surface border-b border-border flex-shrink-0">
@@ -609,6 +613,15 @@ function FileHeader({
               <Columns2 className="w-3.5 h-3.5" />
             </button>
           </div>
+        )}
+        {onToggleWorkflowTips && (
+          <button
+            onClick={onToggleWorkflowTips}
+            className="p-1.5 rounded text-text-secondary hover:text-text-primary transition-colors cursor-pointer"
+            title="Workflow tips"
+          >
+            <Lightbulb className="w-4 h-4" />
+          </button>
         )}
         {onToggleHotkeyGuide && (
           <button

--- a/packages/ui/src/components/ReviewView.tsx
+++ b/packages/ui/src/components/ReviewView.tsx
@@ -4,6 +4,7 @@ import { FileBrowser } from "./FileBrowser";
 import { DiffViewer } from "./DiffViewer";
 import { ActionBar } from "./ActionBar";
 import { HotkeyGuide } from "./HotkeyGuide";
+import { WorkflowTips } from "./WorkflowTips";
 import { AnnotationPanel } from "./AnnotationPanel";
 import { useReviewStore } from "../store/review";
 import type { ReviewResult } from "../types";
@@ -66,6 +67,7 @@ export function ReviewView({ onSubmit, onDismiss, isWatchMode, watchSubmitted, h
         hasUnreviewedChanges={hasUnreviewedChanges}
       />
       <HotkeyGuide />
+      <WorkflowTips />
     </div>
   );
 }

--- a/packages/ui/src/components/WorkflowTips/WorkflowTips.tsx
+++ b/packages/ui/src/components/WorkflowTips/WorkflowTips.tsx
@@ -1,0 +1,107 @@
+import { useEffect } from "react";
+import { useReviewStore } from "../../store/review";
+import {
+  WORKFLOW_TIPS,
+  CATEGORY_ORDER,
+  CATEGORY_LABELS,
+} from "../../data/workflow-tips";
+import type { TipCategory } from "../../data/workflow-tips";
+
+const STORAGE_KEY = "diffprism-tips-seen";
+
+export function WorkflowTips() {
+  const { showWorkflowTips, toggleWorkflowTips } = useReviewStore();
+
+  // Auto-show on first visit
+  useEffect(() => {
+    if (!localStorage.getItem(STORAGE_KEY)) {
+      localStorage.setItem(STORAGE_KEY, "1");
+      toggleWorkflowTips();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Close on Escape
+  useEffect(() => {
+    if (!showWorkflowTips) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        toggleWorkflowTips();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [showWorkflowTips, toggleWorkflowTips]);
+
+  if (!showWorkflowTips) return null;
+
+  // Group tips by category
+  const grouped = new Map<TipCategory, typeof WORKFLOW_TIPS>();
+  for (const tip of WORKFLOW_TIPS) {
+    if (!grouped.has(tip.category)) grouped.set(tip.category, []);
+    grouped.get(tip.category)!.push(tip);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={toggleWorkflowTips}
+    >
+      <div
+        className="bg-surface border border-border rounded-lg shadow-xl p-6 max-w-md w-full mx-4 max-h-[80vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-text-primary text-sm font-semibold mb-4">
+          Workflow Tips
+        </h2>
+
+        <div className="space-y-4">
+          {CATEGORY_ORDER.map((category) => {
+            const tips = grouped.get(category);
+            if (!tips || tips.length === 0) return null;
+
+            return (
+              <div key={category}>
+                <h3 className="text-text-secondary text-xs font-semibold uppercase tracking-wider mb-2">
+                  {CATEGORY_LABELS[category]}
+                </h3>
+                <div className="space-y-1.5">
+                  {tips.map((tip) => (
+                    <div
+                      key={tip.id}
+                      className="flex items-start justify-between gap-3"
+                    >
+                      <span className="text-text-secondary text-sm leading-snug">
+                        {tip.text}
+                      </span>
+                      {tip.shortcut && (
+                        <kbd className="flex-shrink-0 px-1.5 py-0.5 text-xs font-mono rounded border border-border bg-background text-text-primary whitespace-nowrap">
+                          {tip.shortcut}
+                        </kbd>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-5 flex items-center justify-between">
+          <span className="text-text-secondary/60 text-xs">
+            Reopen anytime from the toolbar
+          </span>
+          <button
+            onClick={toggleWorkflowTips}
+            className="px-3 py-1.5 text-sm font-medium rounded bg-accent text-white hover:bg-accent/90 transition-colors cursor-pointer"
+          >
+            Got it
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/WorkflowTips/index.ts
+++ b/packages/ui/src/components/WorkflowTips/index.ts
@@ -1,0 +1,1 @@
+export { WorkflowTips } from "./WorkflowTips";

--- a/packages/ui/src/data/workflow-tips.ts
+++ b/packages/ui/src/data/workflow-tips.ts
@@ -1,0 +1,100 @@
+/**
+ * Workflow Tips — single source of truth for the tips overlay.
+ *
+ * To add a tip:   append an entry to WORKFLOW_TIPS below.
+ * To add a category: add to TipCategory union, CATEGORY_LABELS, and CATEGORY_ORDER.
+ * No component changes needed.
+ */
+
+export type TipCategory = "navigation" | "review" | "commenting" | "general";
+
+export interface TipDefinition {
+  /** Unique identifier (used as React key) */
+  id: string;
+  /** Tip text shown to the user */
+  text: string;
+  /** Optional keyboard shortcut displayed as a <kbd> badge */
+  shortcut?: string;
+  /** Category for grouping */
+  category: TipCategory;
+}
+
+/** Human-readable labels for each category */
+export const CATEGORY_LABELS: Record<TipCategory, string> = {
+  navigation: "Navigation",
+  review: "Review Workflow",
+  commenting: "Commenting",
+  general: "General",
+};
+
+/** Display order for categories */
+export const CATEGORY_ORDER: TipCategory[] = [
+  "navigation",
+  "review",
+  "commenting",
+  "general",
+];
+
+export const WORKFLOW_TIPS: TipDefinition[] = [
+  {
+    id: "nav-files",
+    text: "Navigate between files in the sidebar",
+    shortcut: "j / k",
+    category: "navigation",
+  },
+  {
+    id: "nav-hunks",
+    text: "Jump between changed hunks within a file",
+    shortcut: "n / p",
+    category: "navigation",
+  },
+  {
+    id: "nav-select",
+    text: "Click any file in the sidebar to view its diff",
+    category: "navigation",
+  },
+  {
+    id: "review-status",
+    text: "Cycle a file's review status (unreviewed → reviewed → approved → needs changes)",
+    shortcut: "s",
+    category: "review",
+  },
+  {
+    id: "review-split",
+    text: "Toggle between unified and split (side-by-side) diff views from the toolbar",
+    category: "review",
+  },
+  {
+    id: "review-briefing",
+    text: "Check the briefing bar at the top for a summary of changes, risk indicators, and file stats",
+    category: "review",
+  },
+  {
+    id: "comment-gutter",
+    text: "Click a line's gutter (the + icon on hover) to add an inline comment",
+    category: "commenting",
+  },
+  {
+    id: "comment-hunk",
+    text: "Quickly comment on the focused hunk",
+    shortcut: "c",
+    category: "commenting",
+  },
+  {
+    id: "comment-save",
+    text: "Save a comment from the inline form",
+    shortcut: "Cmd/Ctrl + Enter",
+    category: "commenting",
+  },
+  {
+    id: "general-hotkeys",
+    text: "Open the full keyboard shortcuts reference anytime",
+    shortcut: "?",
+    category: "general",
+  },
+  {
+    id: "general-theme",
+    text: "Toggle between dark and light mode from the toolbar",
+    category: "general",
+  },
+];

--- a/packages/ui/src/store/review.ts
+++ b/packages/ui/src/store/review.ts
@@ -59,12 +59,14 @@ export interface ReviewState {
 
   // Server mode (multi-session)
   showHotkeyGuide: boolean;
+  showWorkflowTips: boolean;
   isServerMode: boolean;
   sessions: SessionSummary[];
   activeSessionId: string | null;
 
   // Actions
   toggleHotkeyGuide: () => void;
+  toggleWorkflowTips: () => void;
   initReview: (payload: ReviewInitPayload) => void;
   selectFile: (path: string) => void;
   setConnectionStatus: (status: ReviewState["connectionStatus"]) => void;
@@ -118,6 +120,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   compareRef: null,
   annotations: [],
   showHotkeyGuide: false,
+  showWorkflowTips: false,
   isServerMode: false,
   sessions: [],
   activeSessionId: null,
@@ -231,6 +234,10 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
 
   toggleHotkeyGuide: () => {
     set((state) => ({ showHotkeyGuide: !state.showHotkeyGuide }));
+  },
+
+  toggleWorkflowTips: () => {
+    set((state) => ({ showWorkflowTips: !state.showWorkflowTips }));
   },
 
   toggleTheme: () => {


### PR DESCRIPTION
## What changed

- New data-driven workflow tips overlay (`WorkflowTips` component) that auto-shows on first visit via localStorage flag
- 11 tips across 4 categories (navigation, review, commenting, general) defined in `packages/ui/src/data/workflow-tips.ts`
- Lightbulb icon in the DiffViewer toolbar to reopen tips anytime
- `showWorkflowTips` / `toggleWorkflowTips` added to Zustand store (mirrors `showHotkeyGuide` pattern)

## Why

New users land in the review UI with no guidance on how to use it. The tips overlay provides onboarding without being intrusive — it shows once automatically, then stays accessible from the toolbar.

## Adding/modifying tips

To add a tip: append one entry to the `WORKFLOW_TIPS` array in `workflow-tips.ts`. To add a category: update the `TipCategory` union, `CATEGORY_LABELS`, and `CATEGORY_ORDER` (3 lines in the same file). No component changes needed.

## Testing

- `pnpm test` — all 337 tests pass (including new `toggleWorkflowTips` test)
- `npx tsc --noEmit -p packages/ui/tsconfig.json` — clean
- Reviewed with DiffPrism — approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)