### PR TITLE
patch: bring browser to foreground on new review, fix notifications

### DIFF
--- a/packages/ui/src/__tests__/notifications.test.ts
+++ b/packages/ui/src/__tests__/notifications.test.ts
@@ -64,19 +64,15 @@ function setupNotificationMock(permission: NotificationPermission = "default") {
   return MockNotification;
 }
 
-function setVisibilityState(state: DocumentVisibilityState) {
-  Object.defineProperty(document, "visibilityState", {
-    value: state,
-    writable: true,
-    configurable: true,
-  });
+function setDocumentFocus(focused: boolean) {
+  vi.spyOn(document, "hasFocus").mockReturnValue(focused);
 }
 
 describe("useNotifications", () => {
   beforeEach(() => {
     localStorage.clear();
     notificationInstances = [];
-    setVisibilityState("visible");
+    setDocumentFocus(true);
   });
 
   afterEach(() => {
@@ -106,9 +102,9 @@ describe("useNotifications", () => {
   });
 
   describe("tab focused", () => {
-    it("does not show notification when tab is visible", async () => {
+    it("does not show notification when tab is focused", async () => {
       setupNotificationMock("granted");
-      setVisibilityState("visible");
+      setDocumentFocus(true);
 
       const { result } = renderHook(() => useNotifications());
 
@@ -123,7 +119,7 @@ describe("useNotifications", () => {
   describe("tab hidden + granted", () => {
     it("creates notification with correct content", async () => {
       setupNotificationMock("granted");
-      setVisibilityState("hidden");
+      setDocumentFocus(false);
 
       const { result } = renderHook(() => useNotifications());
 
@@ -142,7 +138,7 @@ describe("useNotifications", () => {
 
     it("uses fallback title when session has no title", async () => {
       setupNotificationMock("granted");
-      setVisibilityState("hidden");
+      setDocumentFocus(false);
 
       const { result } = renderHook(() => useNotifications());
 
@@ -156,7 +152,7 @@ describe("useNotifications", () => {
 
     it("handles session without branch", async () => {
       setupNotificationMock("granted");
-      setVisibilityState("hidden");
+      setDocumentFocus(false);
 
       const { result } = renderHook(() => useNotifications());
 
@@ -172,7 +168,7 @@ describe("useNotifications", () => {
   describe("permission denied", () => {
     it("does not create notification", async () => {
       setupNotificationMock("denied");
-      setVisibilityState("hidden");
+      setDocumentFocus(false);
 
       const { result } = renderHook(() => useNotifications());
 
@@ -187,7 +183,7 @@ describe("useNotifications", () => {
   describe("permission default", () => {
     it("auto-requests permission and notifies if granted", async () => {
       const mock = setupNotificationMock("default");
-      setVisibilityState("hidden");
+      setDocumentFocus(false);
 
       const { result } = renderHook(() => useNotifications());
 
@@ -211,7 +207,7 @@ describe("useNotifications", () => {
         });
         return "denied" as NotificationPermission;
       });
-      setVisibilityState("hidden");
+      setDocumentFocus(false);
 
       const { result } = renderHook(() => useNotifications());
 
@@ -227,7 +223,7 @@ describe("useNotifications", () => {
   describe("localStorage preference", () => {
     it("suppresses notification when disabled even if granted", async () => {
       setupNotificationMock("granted");
-      setVisibilityState("hidden");
+      setDocumentFocus(false);
       localStorage.setItem("diffprism-notifications", "disabled");
 
       const { result } = renderHook(() => useNotifications());
@@ -276,7 +272,7 @@ describe("useNotifications", () => {
   describe("notification click", () => {
     it("calls window.focus, onSessionSelect, and closes notification", async () => {
       setupNotificationMock("granted");
-      setVisibilityState("hidden");
+      setDocumentFocus(false);
 
       const onSessionSelect = vi.fn();
       const focusSpy = vi.spyOn(window, "focus").mockImplementation(() => {});

--- a/packages/ui/src/hooks/useNotifications.ts
+++ b/packages/ui/src/hooks/useNotifications.ts
@@ -56,6 +56,21 @@ export function useNotifications(options?: UseNotificationsOptions): UseNotifica
     return perm;
   }, [hasNotificationApi]);
 
+  // Proactively request permission on first user click when still "default".
+  // Chrome requires a user gesture for requestPermission(), so the auto-request
+  // inside sendNotification (called from a WS handler) silently fails.
+  useEffect(() => {
+    if (!hasNotificationApi || !enabled) return;
+    if (Notification.permission !== "default") return;
+
+    const handler = () => {
+      document.removeEventListener("click", handler, true);
+      void requestPermission();
+    };
+    document.addEventListener("click", handler, true);
+    return () => document.removeEventListener("click", handler, true);
+  }, [hasNotificationApi, enabled, requestPermission]);
+
   const toggle = useCallback(async () => {
     if (!hasNotificationApi) return;
 
@@ -79,7 +94,7 @@ export function useNotifications(options?: UseNotificationsOptions): UseNotifica
   const sendNotification = useCallback(
     async (title: string, body: string, tag?: string, onClick?: () => void) => {
       if (!hasNotificationApi) return;
-      if (document.visibilityState !== "hidden") return;
+      if (document.hasFocus()) return;
       if (!enabled) return;
 
       let currentPermission = permission;

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -82,6 +82,7 @@ export function useWebSocket(options?: UseWebSocketOptions) {
           setSessions(message.payload);
         } else if (message.type === "session:added") {
           addSession(message.payload);
+          window.focus();
           onSessionAddedRef.current?.(message.payload);
         } else if (message.type === "session:updated") {
           updateSession(message.payload);

--- a/ui-dist/index.html
+++ b/ui-dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>DiffPrism</title>
-    <script type="module" crossorigin src="/assets/index-CNIXSkOg.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-vG-fI3wH.css">
+    <script type="module" crossorigin src="/assets/index-DqG6b0pP.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-oPcRh7AZ.css">
   </head>
   <body style="background-color: var(--color-background); margin: 0;">
     <div id="root"></div>


### PR DESCRIPTION
## What changed

- Call `window.focus()` on `session:added` WebSocket message to bring Chrome to the foreground when a new review arrives
- Replace `document.visibilityState !== "hidden"` with `document.hasFocus()` in the notification guard — correctly detects when Chrome is behind other windows
- Add proactive `requestPermission()` on first user click via a capture-phase listener, since Chrome requires a user gesture context
- Update notification tests to mock `document.hasFocus()` instead of `document.visibilityState`

## Why

When a DiffPrism tab was already open, new reviews arrived silently — Chrome stayed behind the terminal. Two bugs compounded:

1. Server-side `reopenBrowserIfNeeded()` skips `open()` when a WS client is connected (correct), but nothing else brought Chrome forward
2. `document.visibilityState` returns `"visible"` even when Chrome is behind other windows, so the notification fallback never fired
3. `Notification.requestPermission()` called from a WS handler (no user gesture) silently fails in Chrome

## Testing

- `pnpm test` — 338 tests pass
- `pnpm run build` — clean build
- Manual: start server, open DiffPrism tab, switch to terminal, submit review via MCP — Chrome comes to foreground

## Release notes

Fix browser not coming to the foreground when new reviews arrive in an already-open DiffPrism tab. Also fixes desktop notifications which were silently broken due to incorrect visibility detection and missing user gesture for permission request.