### PR TITLE
patch: simplify /review skill and auto-update on setup

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -3,76 +3,27 @@ name: review
 description: Open current code changes in DiffPrism's browser-based review UI for human review.
 ---
 
-# DiffPrism Review Skill
+# DiffPrism Review
 
-When the user invokes `/review`, open the current code changes in DiffPrism for browser-based human review.
+When the user invokes `/review`, call `mcp__diffprism__open_review` with:
 
-## Steps
+- `diff_ref`: `"working-copy"` (or what the user specified, e.g. `"staged"`)
+- `title`: Brief summary of the changes
+- `reasoning`: Your reasoning about the implementation decisions
 
-### 1. Check for Watch Mode
+The tool blocks until the human submits their review. Handle the result:
 
-Before opening a new review, check if `diffprism watch` is already running. Look for `.diffprism/watch.json` at the git root. If it exists and the process is alive:
+- **`approved`** — Proceed with the task.
+- **`changes_requested`** — Read comments, make fixes, offer to re-review.
+- If `postReviewAction` is `"commit"` — commit the changes.
+- If `postReviewAction` is `"commit_and_pr"` — commit and open a PR.
 
-- **Do NOT call `open_review`** (the browser is already open with live-updating diffs)
-- Instead, call `mcp__diffprism__update_review_context` to push your reasoning to the existing watch session
-- Then **immediately** call `mcp__diffprism__get_review_result` with `wait: true` to block until the developer submits their review
-- Tell the user: "DiffPrism watch is running — pushed reasoning to the live review. Waiting for your feedback..."
-- When the result comes back, handle it per step 5 below
-- Skip steps 2-4
+## Headless Tools
 
-### 2. Load Configuration
+- `mcp__diffprism__analyze_diff` — Returns analysis JSON (patterns, complexity, test gaps) without opening a browser. Use proactively to self-check before requesting review.
+- `mcp__diffprism__get_diff` — Returns structured diff JSON.
 
-Look for `diffprism.config.json` at the project root. If it exists, read it for preferences. If it doesn't exist, use defaults silently — do not prompt or create the file.
+## Rules
 
-```json
-{
-  "defaultDiffScope": "staged | unstaged | working-copy",
-  "includeReasoning": true | false
-}
-```
-
-**Defaults** (when fields are missing or file doesn't exist):
-- `defaultDiffScope`: `"working-copy"`
-- `includeReasoning`: `true`
-
-### 3. Open the Review
-
-Call `mcp__diffprism__open_review` with:
-
-- `diff_ref`: Use the `defaultDiffScope` from config. If the user specified a scope in their message (e.g., "/review staged"), use that instead.
-- `title`: A short summary of the changes (generate from git status or the user's message).
-- `description`: A brief description of what changed and why.
-- `reasoning`: If `includeReasoning` is `true`, include your reasoning about the implementation decisions.
-
-### 4. Handle the Result
-
-The tool blocks until the user submits their review in the browser. When it returns:
-
-- **`approved`** — Acknowledge and proceed with whatever task was in progress.
-- **`approved_with_comments`** — Note the comments, address any actionable feedback.
-- **`changes_requested`** — Read the comments carefully, make the requested changes, and offer to open another review.
-
-### 5. Error Handling
-
-If the `mcp__diffprism__open_review` tool is not available:
-- Tell the user: "The DiffPrism MCP server isn't configured. Run `npx diffprism start` to set it up, then restart Claude Code."
-
-## Watch Mode: Waiting for Review Feedback
-
-When `diffprism watch` is active (detected via `.diffprism/watch.json`), the developer can submit reviews at any time in the browser.
-
-**After pushing context to a watch session**, call `mcp__diffprism__get_review_result` with `wait: true` to block until the developer submits their review. This polls the result file every 2 seconds and returns as soon as feedback is available (up to 5 minutes by default).
-
-Use this pattern:
-1. Push context via `update_review_context`
-2. Call `get_review_result` with `wait: true` — this blocks until the developer submits
-3. Handle the result (approved, changes_requested, etc.)
-4. If changes were requested, make fixes, push updated context, and call `get_review_result` with `wait: true` again
-
-You can also check for feedback without blocking by calling `get_review_result` without `wait` at natural breakpoints (between tasks, before committing, etc.).
-
-## Behavior Rules
-
-- **IMPORTANT: Do NOT open reviews automatically.** Only open a review when the user explicitly invokes `/review` or directly asks for a review.
-- Do NOT open reviews before commits, after code changes, or at any other time unless the user requests it.
-- Power users can create `diffprism.config.json` manually to customize defaults (diff scope, reasoning).
+- Only open a review when the user explicitly asks (`/review` or "review my changes").
+- Headless tools can be used proactively without user request.

--- a/cli/src/__tests__/setup.test.ts
+++ b/cli/src/__tests__/setup.test.ts
@@ -437,7 +437,7 @@ describe("setup command", () => {
       expect(skillCall).toBeUndefined();
     });
 
-    it("warns when skill content differs without --force", async () => {
+    it("auto-updates skill when content differs", async () => {
       mockExistsSync.mockImplementation((p: fs.PathLike) => {
         const s = p.toString();
         if (s === path.join("/projects/myapp", ".git")) return true;
@@ -452,27 +452,6 @@ describe("setup command", () => {
       });
 
       await setup({});
-
-      expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining("Warning"),
-      );
-    });
-
-    it("overwrites skill content with --force", async () => {
-      mockExistsSync.mockImplementation((p: fs.PathLike) => {
-        const s = p.toString();
-        if (s === path.join("/projects/myapp", ".git")) return true;
-        if (s.includes("SKILL.md")) return true;
-        return false;
-      });
-
-      mockReadFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
-        const s = p.toString();
-        if (s.includes("SKILL.md")) return "old skill content";
-        throw new Error("File not found");
-      });
-
-      await setup({ force: true });
 
       const skillCall = mockWriteFileSync.mock.calls.find(
         (call) => call[0].toString().includes("SKILL.md"),

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -140,12 +140,7 @@ function setupSkill(
     if (existingContent === skillContent) {
       return { action: "skipped", filePath };
     }
-    if (!force) {
-      console.log(
-        `  Warning: ${filePath} exists with different content. Use --force to overwrite.`,
-      );
-      return { action: "skipped", filePath };
-    }
+    // Always update the skill file — it's managed by DiffPrism, not user-edited
   }
 
   if (!fs.existsSync(skillDir)) {


### PR DESCRIPTION
## What changed

- Synced installed `.claude/skills/review/SKILL.md` with the streamlined template in `cli/src/templates/skill.ts`
- Removed watch mode checks (watch mode was removed in v0.34.0) and `diffprism.config.json` pre-reads from the skill
- Changed `diffprism setup` to always update the skill file when content differs, instead of requiring `--force`

## Why

Every `/review` invocation triggered two unnecessary bash calls (checking `watch.json` and `diffprism.config.json`) before opening the review. The skill template was already simplified but the installed SKILL.md hadn't been updated, and `setup` wouldn't auto-update it without `--force`.

## Testing

- `pnpm test` — 337 tests pass
- `pnpm run build` — clean build

## Release notes

Streamline the `/review` skill to call `open_review` directly without pre-checking for removed watch mode or config files. `diffprism setup` now auto-updates stale skill files without requiring `--force`.