### PR TITLE
minor: make DiffPrism discoverable with default action and dashboard onboarding

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -17,6 +17,7 @@
     "@diffprism/github": "workspace:*",
     "@diffprism/mcp-server": "workspace:*",
     "commander": "^13.0.0",
+    "open": "^10.1.0",
     "tsx": "^4.19.0"
   },
   "devDependencies": {

--- a/cli/src/commands/default.ts
+++ b/cli/src/commands/default.ts
@@ -1,0 +1,69 @@
+import open from "open";
+import { isServerAlive, ensureServer } from "@diffprism/core";
+
+declare const DIFFPRISM_VERSION: string;
+
+function formatUptime(seconds: number): string {
+  if (seconds < 60) return `${Math.floor(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`;
+  const hours = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  return `${hours}h ${mins}m`;
+}
+
+interface StatusResponse {
+  running: boolean;
+  pid: number;
+  sessions: number;
+  uptime: number;
+  uiUrl: string | null;
+}
+
+async function fetchStatus(httpPort: number): Promise<StatusResponse> {
+  const response = await fetch(`http://localhost:${httpPort}/api/status`, {
+    signal: AbortSignal.timeout(2000),
+  });
+  return (await response.json()) as StatusResponse;
+}
+
+function printStatus(status: StatusResponse, httpPort: number): void {
+  const version = typeof DIFFPRISM_VERSION !== "undefined" ? DIFFPRISM_VERSION : "0.0.0-dev";
+
+  console.log(`\nDiffPrism v${version}\n`);
+  console.log(`  Server:    running (PID ${status.pid}, uptime ${formatUptime(status.uptime)})`);
+  if (status.uiUrl) {
+    console.log(`  Dashboard: ${status.uiUrl.split("?")[0]}`);
+  } else {
+    console.log(`  API:       http://localhost:${httpPort}`);
+  }
+  console.log(`  Sessions:  ${status.sessions} active`);
+  console.log();
+  console.log(`  Quick start:`);
+  console.log(`    diffprism review           Review local changes`);
+  console.log(`    diffprism review --staged   Review staged changes`);
+  console.log(`    diffprism setup            Set up Claude Code integration`);
+  console.log(`    diffprism --help           Show all commands`);
+  console.log();
+}
+
+export async function defaultAction(): Promise<void> {
+  let info = await isServerAlive();
+
+  if (!info) {
+    console.log("Starting DiffPrism...");
+    info = await ensureServer();
+  }
+
+  try {
+    const status = await fetchStatus(info.httpPort);
+    printStatus(status, info.httpPort);
+
+    if (status.uiUrl) {
+      await open(status.uiUrl);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Error fetching server status: ${message}`);
+    process.exit(1);
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -7,6 +7,7 @@ import { setup } from "./commands/setup.js";
 import { teardown } from "./commands/teardown.js";
 import { demo } from "./commands/demo.js";
 import { server, serverStatus, serverStop } from "./commands/server.js";
+import { defaultAction } from "./commands/default.js";
 
 declare const DIFFPRISM_VERSION: string;
 
@@ -16,6 +17,8 @@ program
   .name("diffprism")
   .description("Local-first code review tool for agent-generated changes")
   .version(typeof DIFFPRISM_VERSION !== "undefined" ? DIFFPRISM_VERSION : "0.0.0-dev");
+
+program.action(defaultAction);
 
 program
   .command("demo")

--- a/packages/core/src/global-server.ts
+++ b/packages/core/src/global-server.ts
@@ -71,6 +71,9 @@ let serverPollInterval = 2000;
 // Module-level callback set by startGlobalServer to reopen browser when needed
 let reopenBrowserIfNeeded: (() => void) | null = null;
 
+// Module-level UI URL for /api/status
+let serverUiUrl: string | null = null;
+
 function toSummary(session: Session): SessionSummary {
   const { payload } = session;
   const fileCount = payload.diffSet.files.length;
@@ -330,6 +333,7 @@ async function handleApiRequest(
       pid: process.pid,
       sessions: sessions.size,
       uptime: process.uptime(),
+      uiUrl: serverUiUrl,
     });
     return true;
   }
@@ -1052,6 +1056,7 @@ export async function startGlobalServer(
 
   // Open browser to UI
   const uiUrl = `http://localhost:${uiPort}?wsPort=${wsPort}&httpPort=${httpPort}&serverMode=true`;
+  serverUiUrl = uiUrl;
   if (openBrowser) {
     await open(uiUrl);
   }
@@ -1078,6 +1083,7 @@ export async function startGlobalServer(
     clientSessions.clear();
     sessions.clear();
     reopenBrowserIfNeeded = null;
+    serverUiUrl = null;
 
     // Close HTTP server
     await new Promise<void>((resolve) => {

--- a/packages/ui/src/components/Dashboard/Dashboard.tsx
+++ b/packages/ui/src/components/Dashboard/Dashboard.tsx
@@ -3,7 +3,8 @@ import { ReviewView } from "../ReviewView";
 import { NotificationToggle } from "../NotificationToggle";
 import type { NotificationPermission } from "../../hooks/useNotifications";
 import type { ReviewResult, SessionSummary } from "../../types";
-import { FileCode } from "lucide-react";
+import { FileCode, Terminal, Settings } from "lucide-react";
+import { useState, useEffect } from "react";
 
 interface DashboardProps {
   sessions: SessionSummary[];
@@ -71,31 +72,114 @@ export function Dashboard({
 }
 
 function EmptyDetailPane({ hasAnySessions }: { hasAnySessions: boolean }) {
-  return (
-    <div className="flex flex-col items-center justify-center h-full text-center px-8">
-      <div className="w-14 h-14 rounded-full bg-surface border border-border flex items-center justify-center mb-4">
-        <FileCode className="w-7 h-7 text-text-secondary" />
+  if (hasAnySessions) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-center px-8">
+        <div className="w-14 h-14 rounded-full bg-surface border border-border flex items-center justify-center mb-4">
+          <FileCode className="w-7 h-7 text-text-secondary" />
+        </div>
+        <h2 className="text-text-primary text-lg font-semibold mb-2">
+          Select a session
+        </h2>
+        <p className="text-text-secondary text-sm max-w-sm">
+          Click a session in the sidebar to view its diff, annotations, and submit your review.
+        </p>
       </div>
-      {hasAnySessions ? (
-        <>
-          <h2 className="text-text-primary text-lg font-semibold mb-2">
-            Select a session
-          </h2>
-          <p className="text-text-secondary text-sm max-w-sm">
-            Click a session in the sidebar to view its diff, annotations, and submit your review.
+    );
+  }
+
+  return <OnboardingPane />;
+}
+
+function OnboardingPane() {
+  const [serverStatus, setServerStatus] = useState<{
+    pid: number;
+    uptime: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const httpPort = params.get("httpPort");
+    if (!httpPort) return;
+
+    fetch(`http://localhost:${httpPort}/api/status`)
+      .then((res) => res.json())
+      .then((data) => {
+        const status = data as { pid: number; uptime: number };
+        setServerStatus(status);
+      })
+      .catch(() => {});
+  }, []);
+
+  const formatUptime = (seconds: number): string => {
+    if (seconds < 60) return `${Math.floor(seconds)}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`;
+    const hours = Math.floor(seconds / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    return `${hours}h ${mins}m`;
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full px-8">
+      <div className="max-w-md w-full">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-text-primary text-2xl font-bold mb-1">DiffPrism</h1>
+          <p className="text-text-secondary text-sm">
+            Code review for AI-generated changes
           </p>
-        </>
-      ) : (
-        <>
-          <h2 className="text-text-primary text-lg font-semibold mb-2">
-            No reviews yet
-          </h2>
-          <p className="text-text-secondary text-sm max-w-sm">
-            Reviews from Claude Code sessions will appear here automatically when they use the{" "}
-            <code className="text-accent text-xs">open_review</code> tool.
+        </div>
+
+        {/* Getting Started card */}
+        <div className="bg-surface border border-border rounded-lg p-6">
+          <h2 className="text-text-primary text-sm font-semibold mb-4">Getting Started</h2>
+
+          {/* From the terminal */}
+          <div className="mb-5">
+            <div className="flex items-center gap-2 mb-2">
+              <Terminal className="w-4 h-4 text-text-secondary" />
+              <span className="text-text-secondary text-xs font-medium">From the terminal</span>
+            </div>
+            <div className="space-y-1.5 pl-6">
+              <code className="block text-accent text-xs">$ diffprism review</code>
+              <code className="block text-accent text-xs">$ diffprism review --staged</code>
+            </div>
+          </div>
+
+          {/* From Claude Code */}
+          <div className="mb-5">
+            <div className="flex items-center gap-2 mb-2">
+              <FileCode className="w-4 h-4 text-text-secondary" />
+              <span className="text-text-secondary text-xs font-medium">From Claude Code</span>
+            </div>
+            <p className="text-text-secondary text-xs pl-6">
+              Type <code className="text-accent">/review</code> or use the{" "}
+              <code className="text-accent">open_review</code> MCP tool
+            </p>
+          </div>
+
+          {/* First time */}
+          <div>
+            <div className="flex items-center gap-2 mb-2">
+              <Settings className="w-4 h-4 text-text-secondary" />
+              <span className="text-text-secondary text-xs font-medium">First time?</span>
+            </div>
+            <div className="pl-6">
+              <code className="block text-accent text-xs mb-1">$ diffprism setup</code>
+              <p className="text-text-secondary text-xs">
+                Configures Claude Code integration in one command
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Server status footer */}
+        {serverStatus && (
+          <p className="text-text-secondary text-xs text-center mt-4">
+            Server running · PID {serverStatus.pid} · up {formatUptime(serverStatus.uptime)}
           </p>
-        </>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       commander:
         specifier: ^13.0.0
         version: 13.1.0
+      open:
+        specifier: ^10.1.0
+        version: 10.2.0
       tsx:
         specifier: ^4.19.0
         version: 4.21.0


### PR DESCRIPTION
## What changed

- **CLI default action:** Running `diffprism` with no arguments now checks for a running server (starts one if needed), prints a compact status summary (version, PID, uptime, session count, quick start commands), and opens the dashboard in the browser
- **`/api/status` enhancement:** Added `uiUrl` field to the status endpoint so the CLI can discover the dashboard URL programmatically
- **Dashboard onboarding:** Replaced the "No reviews yet" empty state with a Getting Started card showing terminal commands, Claude Code usage, and first-time setup instructions, plus a live server status footer

## Why

DiffPrism disappears after install — no README visible, no obvious way to start it. The browser dashboard is the real product, but users don't know to go there. These changes make DiffPrism feel like a tool you actively use rather than invisible infrastructure.

## Testing
- `pnpm test` — all tests pass
- `npx tsc --noEmit` — core and CLI type-check clean
- Manual: `diffprism` with no args → prints status + opens browser
- Manual: dashboard with no sessions → shows onboarding card

## Release Notes

- Running `diffprism` with no arguments now checks/starts the server, prints a status summary, and opens the dashboard
- The `/api/status` endpoint now includes `uiUrl` for programmatic dashboard access
- Dashboard empty state replaced with an onboarding view showing getting-started commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)