### PR TITLE
patch: Fix X button overlapping status badge on session cards

### DIFF
--- a/packages/ui/src/components/SessionSidebar/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar/SessionSidebar.tsx
@@ -107,7 +107,7 @@ export function SessionSidebar({ sessions, activeSessionId, onSelect, onClose }:
                   </button>
 
                   {/* Row 1: Title + attention/status */}
-                  <div className="flex items-start justify-between gap-1.5 mb-1">
+                  <div className="flex items-start justify-between gap-1.5 mb-1 pr-7">
                     <div className="flex items-center gap-1.5 min-w-0 flex-1">
                       {session.needsAttention && (
                         <AlertCircle className="w-3.5 h-3.5 text-warning flex-shrink-0 animate-pulse" />


### PR DESCRIPTION
## Summary
- Fixes the close (X) button overlapping with the "In Review" status badge on session cards in the sidebar
- Adds right padding to the title row to ensure the badge and close button don't collide

## Test plan
- [ ] Open DiffPrism with an active review session
- [ ] Verify the "In Review" badge and X button don't overlap
- [ ] Verify the X button still works and appears on hover
- [ ] Test with long session titles to ensure proper truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)