### PR TITLE
patch: Fix sidebar content bleeding into diff viewer

### DIFF
--- a/packages/ui/src/components/ReviewView.tsx
+++ b/packages/ui/src/components/ReviewView.tsx
@@ -43,7 +43,7 @@ export function ReviewView({ onSubmit, onDismiss, isWatchMode, watchSubmitted, h
       <ReasoningPanel />
       <div className="flex flex-1 min-h-0">
         {/* Left sidebar — File Browser + Annotations */}
-        <div className="w-[280px] flex-shrink-0 flex flex-col">
+        <div className="w-[280px] flex-shrink-0 flex flex-col overflow-hidden">
           <div className="flex-1 min-h-0">
             <FileBrowser onSubmit={onSubmit} />
           </div>


### PR DESCRIPTION
## Summary
- Fixes sidebar text and elements visually overflowing into the diff viewer area
- Adds overflow containment to the sidebar container to properly clip content within its 280px width

## Test plan
- [ ] Open a review with files that have long names or many stats
- [ ] Verify no sidebar content appears over the diff viewer
- [ ] Verify sidebar content is properly truncated/clipped
- [ ] Resize window to confirm layout stays contained

🤖 Generated with [Claude Code](https://claude.com/claude-code)