### PR TITLE
patch: Fix sidebar sections overlap in review view

### DIFF
--- a/packages/ui/src/components/AnnotationPanel/AnnotationPanel.tsx
+++ b/packages/ui/src/components/AnnotationPanel/AnnotationPanel.tsx
@@ -85,7 +85,7 @@ export function AnnotationPanel({
   if (annotations.length === 0) return null;
 
   return (
-    <div className="border-t border-border">
+    <div className="border-t border-border flex-shrink-0 max-h-[40%] overflow-hidden flex flex-col">
       <div className="px-4 py-2 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Bot className="w-4 h-4 text-text-secondary" />
@@ -108,7 +108,7 @@ export function AnnotationPanel({
         )}
       </div>
 
-      <div className="max-h-64 overflow-y-auto">
+      <div className="flex-1 min-h-0 overflow-y-auto">
         {Array.from(grouped.entries()).map(([agent, agentAnnotations]) => (
           <div key={agent} className="border-t border-border/50">
             <div className="px-4 py-1.5 flex items-center gap-2">

--- a/packages/ui/src/components/FileBrowser/FileBrowser.tsx
+++ b/packages/ui/src/components/FileBrowser/FileBrowser.tsx
@@ -379,7 +379,7 @@ export function FileBrowser({ onSubmit }: FileBrowserProps) {
   };
 
   return (
-    <div className="flex flex-col h-full bg-surface border-r border-border">
+    <div className="flex flex-col h-full overflow-hidden bg-surface border-r border-border">
       {/* Header */}
       <div className="px-4 py-3 border-b border-border">
         <div className="flex items-center justify-between">

--- a/packages/ui/src/components/ReviewView.tsx
+++ b/packages/ui/src/components/ReviewView.tsx
@@ -43,7 +43,7 @@ export function ReviewView({ onSubmit, onDismiss, isWatchMode, watchSubmitted, h
       <ReasoningPanel />
       <div className="flex flex-1 min-h-0">
         {/* Left sidebar — File Browser + Annotations */}
-        <div className="w-[280px] flex-shrink-0 flex flex-col">
+        <div className="w-[280px] flex-shrink-0 flex flex-col overflow-hidden">
           <div className="flex-1 min-h-0">
             <FileBrowser onSubmit={onSubmit} />
           </div>


### PR DESCRIPTION
## Summary
- Fixes overflow issue where the file list (CHANGES section) and AGENT ANNOTATIONS panel overlap in the review sidebar
- Adds `overflow-hidden` to the sidebar container and FileBrowser outer div to properly clip content
- Changes AnnotationPanel to use `flex-shrink-0 max-h-[40%] overflow-hidden flex flex-col` so it respects the flex layout and doesn't grow unbounded
- Replaces fixed `max-h-64` on the annotation scroll container with `flex-1 min-h-0 overflow-y-auto` so scrolling works within the constrained parent

## Test plan
- [ ] Open a review with many files and agent annotations
- [ ] Verify file list scrolls independently without bleeding into annotations
- [ ] Verify annotation panel stays contained at bottom of sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)