### PR TITLE
minor: GitHub PR super-review with MCP-powered AI tools

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -5,25 +5,99 @@ description: Open current code changes in DiffPrism's browser-based review UI fo
 
 # DiffPrism Review
 
-When the user invokes `/review`, call `mcp__diffprism__open_review` with:
+You have 14 DiffPrism MCP tools available. Use them proactively — don't wait for the user to ask.
 
-- `diff_ref`: `"working-copy"` (or what the user specified, e.g. `"staged"`)
-- `title`: Brief summary of the changes
-- `reasoning`: Your reasoning about the implementation decisions
+## Workflow 1: Self-Review Before Human Review
 
-The tool blocks until the human submits their review. Handle the result:
+After making multi-file changes, **proactively self-review before requesting human review**:
 
+1. Run `mcp__diffprism__analyze_diff` with `diff_ref: "working-copy"`
+2. Check the response for:
+   - **Pattern flags** — console.logs left in, TODO comments, security issues (hardcoded secrets, SQL injection, XSS)
+   - **Test coverage gaps** — new code paths without corresponding tests
+   - **High complexity scores** — functions or files with elevated complexity
+3. **Fix any issues found** — remove debug logs, add missing tests, simplify complex code
+4. Only then open a human review with `mcp__diffprism__open_review`
+
+This should happen automatically after significant changes. You don't need the user to ask.
+
+## Workflow 2: Annotated Human Review
+
+When opening a review, help the reviewer by flagging what matters:
+
+1. Call `mcp__diffprism__open_review` with:
+   - `diff_ref`: `"working-copy"` (or what the user specified, e.g. `"staged"`, `"HEAD~3..HEAD"`)
+   - `title`: Brief summary of the changes
+   - `reasoning`: Your reasoning about implementation decisions
+   - `annotations`: Array of inline findings to pre-populate the review (see tool schema)
+2. Use annotations to flag:
+   - Areas of uncertainty ("I chose approach X over Y because...")
+   - Security-sensitive changes
+   - Performance implications
+   - Anything the reviewer should look at closely
+3. After opening, use `mcp__diffprism__flag_for_attention` to highlight files that need careful review (e.g. auth logic, data migrations, public API changes)
+4. Use `mcp__diffprism__add_annotation` to post additional findings about specific lines if you discover issues while the review is open
+
+Handle the review result:
 - **`approved`** — Proceed with the task.
 - **`changes_requested`** — Read comments, make fixes, offer to re-review.
 - If `postReviewAction` is `"commit"` — commit the changes.
 - If `postReviewAction` is `"commit_and_pr"` — commit and open a PR.
 
-## Headless Tools
+## Workflow 3: PR Super Review
 
-- `mcp__diffprism__analyze_diff` — Returns analysis JSON (patterns, complexity, test gaps) without opening a browser. Use proactively to self-check before requesting review.
-- `mcp__diffprism__get_diff` — Returns structured diff JSON.
+When the user opens a GitHub PR for review (via `diffprism review <PR URL>` or the DiffPrism UI), you become their AI-powered code reviewer. The diff is visible in the browser; you provide the intelligence.
+
+### Getting oriented
+1. Call `mcp__diffprism__get_pr_context` to understand the PR: title, author, branches, file list, briefing summary, and whether a local repo is connected.
+
+### Investigating changes
+2. Call `mcp__diffprism__get_file_diff` for specific files to see their hunks and triage category (critical/notable/mechanical).
+3. Call `mcp__diffprism__get_file_context` to read full files from the local repo — this gives you surrounding code, not just diff hunks. Use this to understand how changed code fits into the broader file.
+4. Call `mcp__diffprism__get_user_focus` to see what file/line the user is currently viewing in the browser. Proactively offer context about what they're looking at.
+
+### Leaving findings
+5. Call `mcp__diffprism__add_review_comment` to post findings directly to the browser UI. Comments appear as inline annotations on the diff in real-time. Use this to flag issues, suggest improvements, or answer the user's questions visually.
+6. Call `mcp__diffprism__get_review_comments` to see what's already been noted before adding your own.
+
+### Key principle
+The user sees the diff in the browser. You see it through MCP tools. Work together — they spot visual patterns, you analyze logic and context.
+
+## Tool Reference
+
+### Review Lifecycle
+| Tool | Purpose |
+|------|---------|
+| `open_review` | Open browser review UI for local changes or a GitHub PR. |
+| `get_review_result` | Fetch result from a previous review. |
+| `update_review_context` | Push updated reasoning/description to a running review session. |
+
+### Headless Analysis
+| Tool | Purpose |
+|------|---------|
+| `analyze_diff` | Returns analysis JSON (patterns, complexity, test gaps) without opening a browser. |
+| `get_diff` | Returns structured diff JSON (file-level and hunk-level changes). |
+
+### PR Super Review
+| Tool | Purpose |
+|------|---------|
+| `get_pr_context` | High-level PR overview: metadata, briefing, file list, local repo status. |
+| `get_file_diff` | Diff hunks for a specific file with triage category. |
+| `get_file_context` | Full file content from local repo via `git show`. |
+| `get_user_focus` | What file/line the user is currently viewing in the browser UI. |
+
+### Annotation & Commenting
+| Tool | Purpose |
+|------|---------|
+| `add_review_comment` | Post a comment that appears inline in the browser diff. |
+| `get_review_comments` | Read all comments and annotations on the session. |
+| `add_annotation` | Post a structured finding (finding/suggestion/question/warning). |
+| `flag_for_attention` | Mark files for human attention with warning annotations. |
+| `get_review_state` | Get current state of a review session including all annotations. |
 
 ## Rules
 
-- Only open a review when the user explicitly asks (`/review` or "review my changes").
-- Headless tools can be used proactively without user request.
+- **Self-review is proactive** — run `analyze_diff` after significant changes without being asked.
+- **Human review requires explicit request** — only open `open_review` when the user asks (`/review`, "review my changes", or as part of a defined workflow like PR creation).
+- **Annotate generously** — the more context you provide in annotations, the faster the reviewer can make decisions.
+- **PR review is conversational** — when a PR is open, use the super review tools to answer questions and post findings without being asked to use specific tools.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ packages/core       — Shared types (types.ts), server-client utilities, global
 packages/git        — Git diff execution + unified diff parser (no deps beyond Node built-ins)
 packages/analysis   — Deterministic review briefing (no deps beyond core types)
 packages/ui         — React 19 + Vite 6 + Tailwind 3 + Zustand 5 + react-diff-view + refractor
-packages/mcp-server — MCP tool server (9 tools), all reviews route through global server
+packages/mcp-server — MCP tool server (14 tools), all reviews route through global server
 packages/github     — GitHub PR fetching, normalization, and review submission
 cli/                — Commander CLI (review, serve, setup, server commands), bin shim using tsx
 ```
@@ -34,7 +34,7 @@ cli/                — Commander CLI (review, serve, setup, server commands), b
 | `packages/ui/src/store/review.ts` | Zustand store (all UI state) |
 | `packages/ui/src/hooks/useWebSocket.ts` | WS connection + state dispatch |
 | `packages/ui/vite.config.ts` | Vite config with inline PostCSS (Tailwind path fix) |
-| `packages/mcp-server/src/index.ts` | MCP server — 9 tools, all routed through global server |
+| `packages/mcp-server/src/index.ts` | MCP server — 14 tools, all routed through global server |
 | `cli/src/commands/setup.ts` | `diffprism setup` — one-command Claude Code integration |
 | `cli/src/commands/server.ts` | `diffprism server` — start/status/stop global server |
 | `cli/src/templates/skill.ts` | Embedded `/review` skill content (SKILL.md template) |

--- a/README.md
+++ b/README.md
@@ -1,30 +1,97 @@
 # DiffPrism
 
-Your AI writes code — you need to review it before it ships. But terminal diffs
-are hard to read, and there's no way to leave structured feedback that the agent
-actually acts on.
-
-DiffPrism opens a code review UI in your browser with syntax-highlighted diffs,
-inline commenting, and structured decisions (approve / request changes) that
-Claude reads and responds to.
+Review GitHub PRs with AI superpowers. Paste a PR URL, see the diff in your browser, and use Claude Code or Cursor to interrogate every line, file, and change. Your AI gets full codebase context from your local clone — not just the diff hunks.
 
 ## How It Works
 
-1. Type `/review` in Claude Code — your browser opens with the diff
-2. Review the changes, leave inline comments, approve or request changes
-3. Claude reads your decision and acts on it (commits, opens a PR, or fixes what you flagged)
+1. **Open a PR** — `diffprism review https://github.com/owner/repo/pull/123`
+2. **See the diff** — Browser opens with syntax-highlighted diffs, file browser, and analysis briefing
+3. **Ask your AI** — In Claude Code or Cursor, ask questions about the changes. Your AI calls MCP tools to get context and posts findings inline on the diff.
 
-## Setup for Claude Code
+```
+$ cd ~/dev/my-project
+$ diffprism review https://github.com/owner/repo/pull/123
+  Fetching PR #123 from owner/repo...
+  Add retry logic to API client
+  4 files changed
+  Local repo: /Users/you/dev/my-project
 
-```bash
-npx diffprism setup
+  Review open in browser. Use Claude Code to ask questions about this PR.
 ```
 
-Configures everything and opens a demo review so you can see it in action. Restart Claude Code afterward to load the MCP server.
+Then in Claude Code:
 
-## Use from the CLI
+```
+> What does this PR change?
+  → calls get_pr_context → high-level overview
 
-No setup needed — just run:
+> Is the retry logic in client.ts correct?
+  → calls get_file_diff + get_file_context → full file from your local clone
+
+> Flag line 47 as a concern
+  → calls add_review_comment → annotation appears on the diff in your browser
+```
+
+## Setup
+
+```bash
+npm install -g diffprism
+diffprism setup          # Register MCP server with Claude Code
+```
+
+Run the server from within your local clone so the AI gets full file context:
+
+```bash
+cd ~/dev/my-project
+diffprism server         # Or let it auto-start on first review
+```
+
+## PR Review
+
+```bash
+diffprism review https://github.com/owner/repo/pull/123   # Full GitHub URL
+diffprism review owner/repo#123                            # Shorthand format
+```
+
+The server auto-detects your local clone by matching `git remote -v` against the PR's repo. Your AI can then read full files via `git show` — not just diff hunks.
+
+## MCP Tools
+
+DiffPrism exposes 14 MCP tools to your AI:
+
+### PR Review
+| Tool | Purpose |
+|------|---------|
+| `get_pr_context` | High-level PR overview: metadata, briefing, file list, local repo status |
+| `get_file_diff` | Diff hunks for a specific file with triage category |
+| `get_file_context` | Full file content from local repo via `git show` |
+| `add_review_comment` | Post a comment that appears inline on the diff in real-time |
+| `get_review_comments` | Read all comments and annotations on the session |
+| `get_user_focus` | What file/line the user is currently viewing in the browser |
+
+### Review Lifecycle
+| Tool | Purpose |
+|------|---------|
+| `open_review` | Open browser review UI for local changes or a GitHub PR |
+| `get_review_result` | Fetch result from a previous review |
+| `update_review_context` | Push updated reasoning/description to a running session |
+
+### Analysis
+| Tool | Purpose |
+|------|---------|
+| `analyze_diff` | Returns analysis JSON (patterns, complexity, test gaps) |
+| `get_diff` | Returns structured diff JSON (file-level and hunk-level changes) |
+
+### Annotation
+| Tool | Purpose |
+|------|---------|
+| `add_annotation` | Post a structured finding on a specific line |
+| `flag_for_attention` | Mark files for human attention |
+| `get_review_state` | Get current state of a session including all annotations |
+
+## Local Agent Review
+
+DiffPrism also works for reviewing local agent-generated changes:
 
 ```bash
 diffprism review                    # Review all changes (staged + unstaged)
@@ -33,35 +100,31 @@ diffprism review HEAD~3             # Last 3 commits
 diffprism review main..feature      # Branch diff
 ```
 
-## Multi-Agent Reviews
-
-Running multiple Claude Code sessions (e.g., in git worktrees)? All reviews appear in one browser tab.
-
-The server starts automatically on first use — no manual setup needed. Each review shows up as a session with status badges, branch info, and change stats. Click to switch between reviews. Desktop notifications alert you when new reviews arrive.
-
-```bash
-diffprism server status             # Check if server is running
-diffprism server stop               # Stop the background server
-```
+Running multiple Claude Code sessions? All reviews appear in one browser dashboard with status badges, branch info, and desktop notifications.
 
 ## Features
 
-- **Syntax-highlighted diffs** — unified or split (side-by-side) view
-- **Inline commenting** — click any line to add `must_fix`, `suggestion`, `question`, or `nitpick` comments
-- **Review briefing** — complexity scores, test coverage gaps, pattern flags, dependency tracking
-- **Agent reasoning panel** — see why the AI made each change
-- **Quick actions** — Approve & Commit or Approve, Commit & PR from the review UI
-- **Multi-session dashboard** — review multiple agents from one browser tab
-- **Desktop notifications** — get alerted when a new review arrives
-- **GitHub PR review** — review any GitHub PR in DiffPrism's UI
-- **Keyboard shortcuts** — `j`/`k` files, `n`/`p` hunks, `c` comment, `s` status, `?` help
-- **Dark/light mode** — toggle with persistence
+- **AI-powered PR review** — Your AI gets full codebase context via 14 MCP tools
+- **Live annotations** — AI findings appear inline on the diff in real-time
+- **Local repo context** — Full file content from your clone, not just diff hunks
+- **No vendor lock-in** — Works with Claude Code, Cursor, or any MCP client
+- **Syntax-highlighted diffs** — Unified or split view with refractor
+- **Multi-session dashboard** — Review multiple agents from one browser tab
+- **Review briefing** — Complexity scores, test coverage gaps, pattern flags
+- **Auto-detect local repo** — Matches `git remote -v` against the PR's repo
+- **Keyboard shortcuts** — `j`/`k` files, `n`/`p` hunks, `s` status, `?` help
+- **Dark/light mode** — Toggle with persistence
 
-## Uninstall
+## CLI Reference
 
 ```bash
-npx diffprism teardown              # Remove from current project
-npx diffprism teardown --global     # Remove global config
+diffprism review <ref>              # Open a review (PR URL, git ref, or flags)
+diffprism setup                     # Configure Claude Code integration
+diffprism setup --global            # Global setup (no git repo needed)
+diffprism server                    # Start the background server
+diffprism server status             # Check server status
+diffprism server stop               # Stop the server
+diffprism teardown                  # Remove configuration
 ```
 
 ## Development
@@ -82,7 +145,7 @@ packages/core       — Server, types, server-client utilities
 packages/git        — Git diff extraction + parser
 packages/analysis   — Deterministic review briefing
 packages/ui         — React 19 + Vite 6 + Tailwind + Zustand
-packages/mcp-server — MCP tool server (9 tools)
+packages/mcp-server — MCP tool server (14 tools)
 packages/github     — GitHub PR fetching + review submission
 cli/                — Commander CLI
 ```

--- a/cli/src/__tests__/review.test.ts
+++ b/cli/src/__tests__/review.test.ts
@@ -11,22 +11,10 @@ vi.mock("@diffprism/core", () => ({
 
 // Mock @diffprism/github
 const mockIsPrRef = vi.fn();
-const mockResolveGitHubToken = vi.fn();
 const mockParsePrRef = vi.fn();
-const mockCreateGitHubClient = vi.fn();
-const mockFetchPullRequest = vi.fn();
-const mockFetchPullRequestDiff = vi.fn();
-const mockNormalizePr = vi.fn();
-const mockSubmitGitHubReview = vi.fn();
 vi.mock("@diffprism/github", () => ({
   isPrRef: (...args: unknown[]) => mockIsPrRef(...args),
-  resolveGitHubToken: (...args: unknown[]) => mockResolveGitHubToken(...args),
   parsePrRef: (...args: unknown[]) => mockParsePrRef(...args),
-  createGitHubClient: (...args: unknown[]) => mockCreateGitHubClient(...args),
-  fetchPullRequest: (...args: unknown[]) => mockFetchPullRequest(...args),
-  fetchPullRequestDiff: (...args: unknown[]) => mockFetchPullRequestDiff(...args),
-  normalizePr: (...args: unknown[]) => mockNormalizePr(...args),
-  submitGitHubReview: (...args: unknown[]) => mockSubmitGitHubReview(...args),
 }));
 
 import { review } from "../commands/review.js";
@@ -184,68 +172,62 @@ describe("review command", () => {
   describe("PR detection routing", () => {
     it("routes to PR flow when isPrRef returns true", async () => {
       mockIsPrRef.mockReturnValue(true);
-      mockResolveGitHubToken.mockReturnValue("gh-token");
       mockParsePrRef.mockReturnValue({ owner: "acme", repo: "app", number: 42 });
-      mockCreateGitHubClient.mockReturnValue("client");
-      mockFetchPullRequest.mockResolvedValue({
-        owner: "acme", repo: "app", number: 42,
-        title: "Fix bug", author: "dev", url: "https://github.com/acme/app/pull/42",
-        baseBranch: "main", headBranch: "fix-bug", body: null,
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          sessionId: "session-pr-42",
+          fileCount: 1,
+          localRepoPath: "/tmp/app",
+          pr: { title: "Fix bug", author: "dev", url: "https://github.com/acme/app/pull/42", baseBranch: "main", headBranch: "fix-bug" },
+        }),
       });
-      mockFetchPullRequestDiff.mockResolvedValue("diff --git a/file.ts b/file.ts\n");
-      mockNormalizePr.mockReturnValue({
-        payload: { diffSet: { files: [] }, rawDiff: "" },
-        diffSet: { files: [{ additions: 5, deletions: 2 }] },
-      });
-      mockSubmitReviewToServer.mockResolvedValue({
-        result: { decision: "approved", comments: [] },
-        sessionId: "session-pr",
-      });
+      vi.stubGlobal("fetch", mockFetch);
 
       await review("acme/app#42", {});
 
       expect(mockIsPrRef).toHaveBeenCalledWith("acme/app#42");
-      expect(mockResolveGitHubToken).toHaveBeenCalled();
       expect(mockParsePrRef).toHaveBeenCalledWith("acme/app#42");
-      expect(mockSubmitReviewToServer).toHaveBeenCalledWith(
-        defaultServerInfo,
-        "PR #42",
-        expect.objectContaining({
-          injectedPayload: expect.any(Object),
-          projectPath: "github:acme/app",
-        }),
+      expect(mockFetch).toHaveBeenCalledWith(
+        `http://localhost:${defaultServerInfo.httpPort}/api/pr/open`,
+        expect.objectContaining({ method: "POST" }),
       );
-      expect(process.exit).toHaveBeenCalledWith(0);
+
+      vi.unstubAllGlobals();
     });
 
-    it("exits 1 when GitHub token is missing", async () => {
+    it("exits 1 when server returns error", async () => {
       mockIsPrRef.mockReturnValue(true);
-      mockResolveGitHubToken.mockImplementation(() => {
-        throw new Error("GITHUB_TOKEN not set");
+      mockParsePrRef.mockReturnValue({ owner: "acme", repo: "app", number: 42 });
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ error: "GitHub token not found" }),
       });
+      vi.stubGlobal("fetch", mockFetch);
 
       await review("acme/app#42", {});
 
-      expect(console.error).toHaveBeenCalledWith("Error: GITHUB_TOKEN not set");
+      expect(console.error).toHaveBeenCalledWith("Error: GitHub token not found");
       expect(process.exit).toHaveBeenCalledWith(1);
+
+      vi.unstubAllGlobals();
     });
 
-    it("handles empty PR diff", async () => {
+    it("handles server connection failure", async () => {
       mockIsPrRef.mockReturnValue(true);
-      mockResolveGitHubToken.mockReturnValue("gh-token");
       mockParsePrRef.mockReturnValue({ owner: "acme", repo: "app", number: 1 });
-      mockCreateGitHubClient.mockReturnValue("client");
-      mockFetchPullRequest.mockResolvedValue({
-        owner: "acme", repo: "app", number: 1,
-        title: "Empty", author: "dev", url: "https://github.com/acme/app/pull/1",
-        baseBranch: "main", headBranch: "empty", body: null,
-      });
-      mockFetchPullRequestDiff.mockResolvedValue("   ");
+
+      const mockFetch = vi.fn().mockRejectedValue(new Error("Connection refused"));
+      vi.stubGlobal("fetch", mockFetch);
 
       await review("acme/app#1", {});
 
-      expect(console.log).toHaveBeenCalledWith("PR has no changes to review.");
-      expect(mockSubmitReviewToServer).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith("Error: Connection refused");
+      expect(process.exit).toHaveBeenCalledWith(1);
+
+      vi.unstubAllGlobals();
     });
 
     it("does not route to PR flow for local refs", async () => {
@@ -257,7 +239,7 @@ describe("review command", () => {
 
       await review("HEAD~3..HEAD", {});
 
-      expect(mockResolveGitHubToken).not.toHaveBeenCalled();
+      expect(mockParsePrRef).not.toHaveBeenCalled();
       expect(mockSubmitReviewToServer).toHaveBeenCalledWith(
         defaultServerInfo,
         "HEAD~3..HEAD",

--- a/cli/src/commands/review.ts
+++ b/cli/src/commands/review.ts
@@ -1,15 +1,5 @@
-import readline from "node:readline";
 import { ensureServer, submitReviewToServer } from "@diffprism/core";
-import {
-  isPrRef,
-  resolveGitHubToken,
-  parsePrRef,
-  createGitHubClient,
-  fetchPullRequest,
-  fetchPullRequestDiff,
-  normalizePr,
-  submitGitHubReview,
-} from "@diffprism/github";
+import { isPrRef, parsePrRef } from "@diffprism/github";
 
 interface ReviewFlags {
   staged?: boolean;
@@ -73,72 +63,44 @@ async function reviewPrFlow(
   pr: string,
   flags: ReviewFlags,
 ): Promise<void> {
-  // 1. Resolve token
-  const token = resolveGitHubToken();
-
-  // 2. Parse PR ref
   const { owner, repo, number } = parsePrRef(pr);
   console.log(`Fetching PR #${number} from ${owner}/${repo}...`);
 
-  // 3. Fetch PR data
-  const client = createGitHubClient(token);
-  const [prMetadata, rawDiff] = await Promise.all([
-    fetchPullRequest(client, owner, repo, number),
-    fetchPullRequestDiff(client, owner, repo, number),
-  ]);
+  // Auto-start server if needed
+  const serverInfo = await ensureServer({ dev: flags.dev });
 
-  if (!rawDiff.trim()) {
-    console.log("PR has no changes to review.");
-    return;
-  }
-
-  // 4. Normalize to DiffPrism types
-  const { payload, diffSet } = normalizePr(rawDiff, prMetadata, {
-    title: flags.title,
-    reasoning: flags.reasoning,
-  });
-
-  console.log(
-    `${diffSet.files.length} files, +${diffSet.files.reduce((s, f) => s + f.additions, 0)} -${diffSet.files.reduce((s, f) => s + f.deletions, 0)}`,
+  // Use /api/pr/open — handles GitHub fetch + local repo auto-detection
+  const response = await fetch(
+    `http://localhost:${serverInfo.httpPort}/api/pr/open`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prUrl: pr }),
+    },
   );
 
-  // 5. Route through global server (auto-start if needed)
-  const serverInfo = await ensureServer({ dev: flags.dev });
-  const { result } = await submitReviewToServer(serverInfo, `PR #${number}`, {
-    injectedPayload: payload,
-    projectPath: `github:${owner}/${repo}`,
-    diffRef: `PR #${number}`,
-  });
+  const data = await response.json() as {
+    sessionId?: string;
+    fileCount?: number;
+    localRepoPath?: string | null;
+    pr?: { title: string; author: string; url: string; baseBranch: string; headBranch: string };
+    error?: string;
+  };
 
-  console.log(JSON.stringify(result, null, 2));
-
-  // 6. Offer to post review back to GitHub
-  if (result && (flags.postToGithub || (result.decision !== "dismissed" && await promptPostToGithub()))) {
-    console.log("Posting review to GitHub...");
-    const posted = await submitGitHubReview(client, owner, repo, number, result);
-    if (posted) {
-      console.log(`Review posted: ${prMetadata.url}#pullrequestreview-${posted.reviewId}`);
-    }
+  if (!response.ok || !data.sessionId) {
+    console.error(`Error: ${data.error ?? "Failed to open PR"}`);
+    process.exit(1);
   }
 
-  process.exit(0);
-}
+  console.log(`${data.pr?.title ?? `PR #${number}`}`);
+  console.log(`${data.fileCount} file${data.fileCount !== 1 ? "s" : ""} changed`);
 
-async function promptPostToGithub(): Promise<boolean> {
-  // Non-interactive mode (piped stdin)
-  if (!process.stdin.isTTY) {
-    return false;
+  if (data.localRepoPath) {
+    console.log(`Local repo: ${data.localRepoPath}`);
+  } else {
+    console.log("No local clone detected — file context unavailable");
   }
 
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  return new Promise((resolve) => {
-    rl.question("Post this review to GitHub? (y/N) ", (answer) => {
-      rl.close();
-      resolve(answer.toLowerCase() === "y");
-    });
-  });
+  console.log(`\nReview open in browser. Use Claude Code to ask questions about this PR.`);
+  console.log(`MCP tools available: get_pr_context, get_file_diff, get_file_context, add_review_comment`);
 }

--- a/cli/src/templates/skill.ts
+++ b/cli/src/templates/skill.ts
@@ -5,7 +5,7 @@ description: Open current code changes in DiffPrism's browser-based review UI fo
 
 # DiffPrism Review
 
-You have 9 DiffPrism MCP tools available. Use them proactively — don't wait for the user to ask.
+You have 14 DiffPrism MCP tools available. Use them proactively — don't wait for the user to ask.
 
 ## Workflow 1: Self-Review Before Human Review
 
@@ -44,22 +44,32 @@ Handle the review result:
 - If \`postReviewAction\` is \`"commit"\` — commit the changes.
 - If \`postReviewAction\` is \`"commit_and_pr"\` — commit and open a PR.
 
-## Workflow 3: PR Review
+## Workflow 3: PR Super Review
 
-To review a GitHub pull request:
+When the user opens a GitHub PR for review (via \`diffprism review <PR URL>\` or the DiffPrism UI), you become their AI-powered code reviewer. The diff is visible in the browser; you provide the intelligence.
 
-1. Call \`mcp__diffprism__review_pr\` with \`pr: "owner/repo#123"\` or a full GitHub PR URL
-2. Set \`post_to_github: true\` to post the review back to GitHub after the human submits
-3. The tool fetches the PR diff, runs analysis, and opens the review UI
+### Getting oriented
+1. Call \`mcp__diffprism__get_pr_context\` to understand the PR: title, author, branches, file list, briefing summary, and whether a local repo is connected.
+
+### Investigating changes
+2. Call \`mcp__diffprism__get_file_diff\` for specific files to see their hunks and triage category (critical/notable/mechanical).
+3. Call \`mcp__diffprism__get_file_context\` to read full files from the local repo — this gives you surrounding code, not just diff hunks. Use this to understand how changed code fits into the broader file.
+4. Call \`mcp__diffprism__get_user_focus\` to see what file/line the user is currently viewing in the browser. Proactively offer context about what they're looking at.
+
+### Leaving findings
+5. Call \`mcp__diffprism__add_review_comment\` to post findings directly to the browser UI. Comments appear as inline annotations on the diff in real-time. Use this to flag issues, suggest improvements, or answer the user's questions visually.
+6. Call \`mcp__diffprism__get_review_comments\` to see what's already been noted before adding your own.
+
+### Key principle
+The user sees the diff in the browser. You see it through MCP tools. Work together — they spot visual patterns, you analyze logic and context.
 
 ## Tool Reference
 
 ### Review Lifecycle
 | Tool | Purpose |
 |------|---------|
-| \`open_review\` | Open browser review UI for local changes. Blocks until submitted. |
-| \`review_pr\` | Open browser review UI for a GitHub PR. Blocks until submitted. |
-| \`get_review_result\` | Fetch result from a previous review (advanced — \`open_review\` already returns it). |
+| \`open_review\` | Open browser review UI for local changes or a GitHub PR. |
+| \`get_review_result\` | Fetch result from a previous review. |
 | \`update_review_context\` | Push updated reasoning/description to a running review session. |
 
 ### Headless Analysis
@@ -68,10 +78,20 @@ To review a GitHub pull request:
 | \`analyze_diff\` | Returns analysis JSON (patterns, complexity, test gaps) without opening a browser. |
 | \`get_diff\` | Returns structured diff JSON (file-level and hunk-level changes). |
 
-### Annotation & Flagging
+### PR Super Review
 | Tool | Purpose |
 |------|---------|
-| \`add_annotation\` | Post a finding/suggestion/question on a specific line in a running review. |
+| \`get_pr_context\` | High-level PR overview: metadata, briefing, file list, local repo status. |
+| \`get_file_diff\` | Diff hunks for a specific file with triage category. |
+| \`get_file_context\` | Full file content from local repo via \`git show\`. |
+| \`get_user_focus\` | What file/line the user is currently viewing in the browser UI. |
+
+### Annotation & Commenting
+| Tool | Purpose |
+|------|---------|
+| \`add_review_comment\` | Post a comment that appears inline in the browser diff. |
+| \`get_review_comments\` | Read all comments and annotations on the session. |
+| \`add_annotation\` | Post a structured finding (finding/suggestion/question/warning). |
 | \`flag_for_attention\` | Mark files for human attention with warning annotations. |
 | \`get_review_state\` | Get current state of a review session including all annotations. |
 
@@ -80,4 +100,5 @@ To review a GitHub pull request:
 - **Self-review is proactive** — run \`analyze_diff\` after significant changes without being asked.
 - **Human review requires explicit request** — only open \`open_review\` when the user asks (\`/review\`, "review my changes", or as part of a defined workflow like PR creation).
 - **Annotate generously** — the more context you provide in annotations, the faster the reviewer can make decisions.
+- **PR review is conversational** — when a PR is open, use the super review tools to answer questions and post findings without being asked to use specific tools.
 `;

--- a/docs/usage/claude-setup.md
+++ b/docs/usage/claude-setup.md
@@ -75,7 +75,7 @@ Create or edit `.mcp.json` in your project root:
 }
 ```
 
-This tells Claude Code to start DiffPrism's MCP server, which exposes 9 review tools.
+This tells Claude Code to start DiffPrism's MCP server, which exposes 14 review tools.
 
 > **Local dev setup:** If you cloned the repo and want to run from source, use:
 > ```json
@@ -162,7 +162,7 @@ Claude will call the `open_review` MCP tool. The DiffPrism server auto-starts as
 
 ## Tool Reference
 
-The MCP server exposes 9 tools:
+The MCP server exposes 14 tools:
 
 ### `open_review`
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@diffprism/git": "workspace:*",
     "@diffprism/analysis": "workspace:*",
+    "@diffprism/github": "workspace:*",
     "ws": "^8.18.0",
     "open": "^10.1.0",
     "get-port": "^7.1.0"

--- a/packages/core/src/global-server.ts
+++ b/packages/core/src/global-server.ts
@@ -48,6 +48,13 @@ const CLEANUP_INTERVAL_MS = 60 * 1000; // 1 minute
 
 // ─── In-memory session store ───
 
+interface UserFocus {
+  file: string | null;
+  lineStart?: number;
+  lineEnd?: number;
+  updatedAt: number;
+}
+
 interface Session {
   id: string;
   payload: ReviewInitPayload;
@@ -61,6 +68,7 @@ interface Session {
   lastDiffSet?: DiffSet;
   hasNewChanges: boolean;
   annotations: Annotation[];
+  userFocus?: UserFocus;
 }
 
 const sessions = new Map<string, Session>();
@@ -558,6 +566,114 @@ async function handleApiRequest(
     return true;
   }
 
+  // POST /api/pr/open — open a GitHub PR as a review session
+  if (method === "POST" && url === "/api/pr/open") {
+    try {
+      const body = await readBody(req);
+      const { prUrl } = JSON.parse(body) as { prUrl: string };
+
+      if (!prUrl) {
+        jsonResponse(res, 400, { error: "Missing prUrl" });
+        return true;
+      }
+
+      // Dynamic import to keep core lightweight
+      const {
+        isPrRef,
+        parsePrRef,
+        resolveGitHubToken,
+        createGitHubClient,
+        fetchPullRequest,
+        fetchPullRequestDiff,
+        normalizePr,
+      } = await import("@diffprism/github");
+
+      if (!isPrRef(prUrl)) {
+        jsonResponse(res, 400, {
+          error: "Invalid PR URL. Expected https://github.com/owner/repo/pull/123 or owner/repo#123",
+        });
+        return true;
+      }
+
+      let token: string;
+      try {
+        token = resolveGitHubToken();
+      } catch (err) {
+        jsonResponse(res, 401, {
+          error: err instanceof Error ? err.message : "GitHub token not found",
+        });
+        return true;
+      }
+
+      const { owner, repo, number: prNumber } = parsePrRef(prUrl);
+      const client = createGitHubClient(token);
+
+      const [prMetadata, rawDiff] = await Promise.all([
+        fetchPullRequest(client, owner, repo, prNumber),
+        fetchPullRequestDiff(client, owner, repo, prNumber),
+      ]);
+
+      const normalized = normalizePr(rawDiff, prMetadata);
+
+      // Auto-detect local repo by checking git remotes in cwd
+      let localRepoPath: string | null = null;
+      try {
+        const { execSync } = await import("node:child_process");
+        const remoteOutput = execSync("git remote -v", {
+          cwd: process.cwd(),
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        const repoPattern = new RegExp(`github\\.com[:/]${owner}/${repo}(\\.git)?\\s`, "i");
+        if (repoPattern.test(remoteOutput)) {
+          localRepoPath = process.cwd();
+        }
+      } catch {
+        // Not in a git repo or git not available — no local context
+      }
+
+      const sessionId = `session-${randomUUID().slice(0, 8)}`;
+      normalized.payload.reviewId = sessionId;
+
+      const session: Session = {
+        id: sessionId,
+        payload: normalized.payload,
+        projectPath: localRepoPath ?? `github:${owner}/${repo}#${prNumber}`,
+        source: "manual",
+        status: "pending",
+        createdAt: Date.now(),
+        result: null,
+        hasNewChanges: false,
+        annotations: [],
+      };
+
+      sessions.set(sessionId, session);
+
+      broadcastToAll({
+        type: "session:added",
+        payload: toSummary(session),
+      });
+
+      jsonResponse(res, 201, {
+        sessionId,
+        fileCount: normalized.diffSet.files.length,
+        localRepoPath,
+        pr: {
+          title: prMetadata.title,
+          author: prMetadata.author,
+          url: prMetadata.url,
+          baseBranch: prMetadata.baseBranch,
+          headBranch: prMetadata.headBranch,
+        },
+      });
+    } catch (err) {
+      jsonResponse(res, 500, {
+        error: err instanceof Error ? err.message : "Failed to fetch PR",
+      });
+    }
+    return true;
+  }
+
   // GET /api/fs/list?path=<dir> — list directory contents for the path picker
   if (method === "GET" && req.url) {
     const parsedUrl = new URL(req.url, "http://localhost");
@@ -621,6 +737,22 @@ async function handleApiRequest(
       return true;
     }
     jsonResponse(res, 200, toSummary(session));
+    return true;
+  }
+
+  // GET /api/reviews/:id/payload — full session data (diffSet, briefing, metadata)
+  const getPayloadParams = matchRoute(method, url, "GET", "/api/reviews/:id/payload");
+  if (getPayloadParams) {
+    const session = sessions.get(getPayloadParams.id);
+    if (!session) {
+      jsonResponse(res, 404, { error: "Session not found" });
+      return true;
+    }
+    jsonResponse(res, 200, {
+      payload: session.payload,
+      projectPath: session.projectPath,
+      annotations: session.annotations,
+    });
     return true;
   }
 
@@ -792,6 +924,50 @@ async function handleApiRequest(
     });
 
     jsonResponse(res, 200, { ok: true });
+    return true;
+  }
+
+  // POST /api/reviews/:id/focus — update user focus state
+  const postFocusParams = matchRoute(method, url, "POST", "/api/reviews/:id/focus");
+  if (postFocusParams) {
+    const session = sessions.get(postFocusParams.id);
+    if (!session) {
+      jsonResponse(res, 404, { error: "Session not found" });
+      return true;
+    }
+
+    try {
+      const body = await readBody(req);
+      const { file, lineStart, lineEnd } = JSON.parse(body) as {
+        file: string | null;
+        lineStart?: number;
+        lineEnd?: number;
+      };
+
+      session.userFocus = {
+        file,
+        lineStart,
+        lineEnd,
+        updatedAt: Date.now(),
+      };
+
+      jsonResponse(res, 200, { ok: true });
+    } catch {
+      jsonResponse(res, 400, { error: "Invalid request body" });
+    }
+    return true;
+  }
+
+  // GET /api/reviews/:id/focus — get user focus state
+  const getFocusParams = matchRoute(method, url, "GET", "/api/reviews/:id/focus");
+  if (getFocusParams) {
+    const session = sessions.get(getFocusParams.id);
+    if (!session) {
+      jsonResponse(res, 404, { error: "Session not found" });
+      return true;
+    }
+
+    jsonResponse(res, 200, { focus: session.userFocus ?? null });
     return true;
   }
 

--- a/packages/mcp-server/CLAUDE.md
+++ b/packages/mcp-server/CLAUDE.md
@@ -4,7 +4,7 @@ MCP (Model Context Protocol) server exposing DiffPrism tools to Claude Code and 
 
 ## Key Files
 
-- `src/index.ts` — `startMcpServer()` creates an McpServer, registers 8 tools, connects StdioServerTransport.
+- `src/index.ts` — `startMcpServer()` creates an McpServer, registers 14 tools, connects StdioServerTransport.
 
 ## Tools
 
@@ -40,6 +40,34 @@ MCP (Model Context Protocol) server exposing DiffPrism tools to Claude Code and 
 ### `flag_for_attention`
 - **Params:** `session_id` (optional), `files` (required array), `source_agent` (optional)
 - **Behavior:** Posts warning annotations for each flagged file to highlight them for human review.
+
+### Super Review Tools
+
+These tools enable AI-powered PR review. The user opens a GitHub PR in the DiffPrism UI, then uses Claude Code / Cursor to interrogate the changes via these MCP tools.
+
+### `get_pr_context`
+- **Params:** `session_id` (optional, defaults to most recent)
+- **Behavior:** Returns high-level PR overview: metadata (title, author, branches, URL), briefing summary, file list with stats, local repo path, and whether a local repo is connected.
+
+### `get_file_diff`
+- **Params:** `file` (required), `session_id` (optional)
+- **Behavior:** Returns the diff hunks for a specific file from the active review session, plus its triage category (critical/notable/mechanical).
+
+### `get_file_context`
+- **Params:** `file` (required), `ref` (optional), `session_id` (optional)
+- **Behavior:** Returns full file content from the local repo via `git show`. Uses the PR's head branch ref by default. Falls back to working tree if git show fails. Requires server to be running from within the repo clone.
+
+### `add_review_comment`
+- **Params:** `file` (required), `line` (required), `body` (required), `type` (optional: "comment"/"suggestion"/"concern"), `session_id` (optional)
+- **Behavior:** Posts a comment to the active review session. Appears as an inline annotation in the DiffPrism browser UI in real-time.
+
+### `get_review_comments`
+- **Params:** `session_id` (optional)
+- **Behavior:** Returns all comments and annotations on the active review session.
+
+### `get_user_focus`
+- **Params:** `session_id` (optional)
+- **Behavior:** Returns which file and line range the user is currently viewing in the DiffPrism UI. The UI reports focus state to the server automatically.
 
 ## Server Interaction
 

--- a/packages/mcp-server/src/__tests__/mcp-server.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-server.test.ts
@@ -77,7 +77,7 @@ describe("mcp-server", () => {
     const { startMcpServer } = await import("../index.js");
     await startMcpServer();
 
-    expect(mockToolFn).toHaveBeenCalledTimes(8);
+    expect(mockToolFn).toHaveBeenCalledTimes(14);
     expect(mockToolFn.mock.calls[0][0]).toBe("open_review");
     expect(mockToolFn.mock.calls[1][0]).toBe("update_review_context");
     expect(mockToolFn.mock.calls[2][0]).toBe("get_review_result");
@@ -86,6 +86,13 @@ describe("mcp-server", () => {
     expect(mockToolFn.mock.calls[5][0]).toBe("add_annotation");
     expect(mockToolFn.mock.calls[6][0]).toBe("get_review_state");
     expect(mockToolFn.mock.calls[7][0]).toBe("flag_for_attention");
+    // Super Review tools
+    expect(mockToolFn.mock.calls[8][0]).toBe("get_pr_context");
+    expect(mockToolFn.mock.calls[9][0]).toBe("get_file_diff");
+    expect(mockToolFn.mock.calls[10][0]).toBe("get_file_context");
+    expect(mockToolFn.mock.calls[11][0]).toBe("add_review_comment");
+    expect(mockToolFn.mock.calls[12][0]).toBe("get_review_comments");
+    expect(mockToolFn.mock.calls[13][0]).toBe("get_user_focus");
   });
 
   it("connects the stdio transport", async () => {

--- a/packages/mcp-server/src/__tests__/mcp-server.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-server.test.ts
@@ -22,22 +22,10 @@ vi.mock("@diffprism/analysis", () => ({
 }));
 
 const mockIsPrRef = vi.fn();
-const mockResolveGitHubToken = vi.fn();
 const mockParsePrRef = vi.fn();
-const mockCreateGitHubClient = vi.fn();
-const mockFetchPullRequest = vi.fn();
-const mockFetchPullRequestDiff = vi.fn();
-const mockNormalizePr = vi.fn();
-const mockSubmitGitHubReview = vi.fn();
 vi.mock("@diffprism/github", () => ({
   isPrRef: (...args: unknown[]) => mockIsPrRef(...args),
-  resolveGitHubToken: (...args: unknown[]) => mockResolveGitHubToken(...args),
   parsePrRef: (...args: unknown[]) => mockParsePrRef(...args),
-  createGitHubClient: (...args: unknown[]) => mockCreateGitHubClient(...args),
-  fetchPullRequest: (...args: unknown[]) => mockFetchPullRequest(...args),
-  fetchPullRequestDiff: (...args: unknown[]) => mockFetchPullRequestDiff(...args),
-  normalizePr: (...args: unknown[]) => mockNormalizePr(...args),
-  submitGitHubReview: (...args: unknown[]) => mockSubmitGitHubReview(...args),
 }));
 
 const mockToolFn = vi.fn();
@@ -254,43 +242,39 @@ describe("mcp-server", () => {
 
     it("routes to PR flow when diff_ref is a PR reference", async () => {
       mockIsPrRef.mockReturnValue(true);
-      mockResolveGitHubToken.mockReturnValue("gh-token");
       mockParsePrRef.mockReturnValue({ owner: "acme", repo: "app", number: 99 });
-      mockCreateGitHubClient.mockReturnValue("client");
-      mockFetchPullRequest.mockResolvedValue({
-        owner: "acme", repo: "app", number: 99,
-        title: "Add feature", author: "dev",
-        url: "https://github.com/acme/app/pull/99",
-        baseBranch: "main", headBranch: "feat", body: null,
+
+      // Mock fetch for /api/pr/open
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          sessionId: "session-pr-99",
+          fileCount: 2,
+          localRepoPath: "/tmp/app",
+          pr: { title: "Add feature", author: "dev", url: "https://github.com/acme/app/pull/99" },
+        }),
       });
-      mockFetchPullRequestDiff.mockResolvedValue("diff --git a/x.ts b/x.ts\n");
-      mockNormalizePr.mockReturnValue({
-        payload: { diffSet: { files: [] }, rawDiff: "" },
-        diffSet: { files: [] },
-      });
-      mockSubmitReviewToServer.mockResolvedValue({
-        result: null,
-        sessionId: "session-pr-99",
-      });
+      vi.stubGlobal("fetch", mockFetch);
 
       const handler = await getToolHandler();
       const result = await handler({ diff_ref: "acme/app#99" });
 
       expect(mockIsPrRef).toHaveBeenCalledWith("acme/app#99");
-      expect(mockResolveGitHubToken).toHaveBeenCalled();
-      expect(mockSubmitReviewToServer).toHaveBeenCalledWith(
-        defaultServerInfo,
-        "PR #99",
+      expect(mockEnsureServer).toHaveBeenCalledWith({ silent: true });
+      expect(mockFetch).toHaveBeenCalledWith(
+        `http://localhost:${defaultServerInfo.httpPort}/api/pr/open`,
         expect.objectContaining({
-          injectedPayload: expect.any(Object),
-          projectPath: "github:acme/app",
-          timeoutMs: 0,
+          method: "POST",
+          body: JSON.stringify({ prUrl: "acme/app#99" }),
         }),
       );
       expect(result.isError).toBeUndefined();
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.status).toBe("session_created");
       expect(parsed.sessionId).toBe("session-pr-99");
+      expect(parsed.localRepoConnected).toBe(true);
+
+      vi.unstubAllGlobals();
     });
   });
 });

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -924,6 +924,449 @@ export async function startMcpServer(): Promise<void> {
     },
   );
 
+  // ─── Super Review Tools ───
+
+  server.tool(
+    "get_pr_context",
+    "Get a high-level overview of the active PR review session. Returns PR metadata (title, author, branches, URL), review briefing summary, file list with stats, and local repo path. Use this to orient yourself before diving into specific files.",
+    {
+      session_id: z
+        .string()
+        .optional()
+        .describe("Review session ID. If omitted, uses the most recently created session."),
+    },
+    async ({ session_id }) => {
+      try {
+        const sessionId = session_id ?? lastGlobalSessionId;
+        if (!sessionId) {
+          return {
+            content: [{ type: "text" as const, text: "No session ID provided and no recent session available. Open a PR review first." }],
+            isError: true,
+          };
+        }
+
+        const serverInfo = await isServerAlive();
+        if (!serverInfo) {
+          return {
+            content: [{ type: "text" as const, text: "No global server running. Start one with `diffprism server`." }],
+            isError: true,
+          };
+        }
+
+        const response = await fetch(
+          `http://localhost:${serverInfo.httpPort}/api/reviews/${sessionId}/payload`,
+        );
+        if (!response.ok) {
+          return {
+            content: [{ type: "text" as const, text: `Session not found: ${sessionId}` }],
+            isError: true,
+          };
+        }
+
+        const data = await response.json() as {
+          payload: { diffSet: { files: Array<{ path: string; status: string; additions: number; deletions: number; language: string }> }; briefing: { summary: string; triage: unknown }; metadata: { title?: string; description?: string; githubPr?: { owner: string; repo: string; number: number; title: string; author: string; url: string; baseBranch: string; headBranch: string } } };
+          projectPath: string;
+        };
+
+        const { payload, projectPath } = data;
+        const result = {
+          sessionId,
+          projectPath,
+          localRepoConnected: !projectPath.startsWith("github:"),
+          pr: payload.metadata.githubPr ?? null,
+          title: payload.metadata.title,
+          description: payload.metadata.description,
+          briefingSummary: payload.briefing.summary,
+          triage: payload.briefing.triage,
+          files: payload.diffSet.files.map((f) => ({
+            path: f.path,
+            status: f.status,
+            additions: f.additions,
+            deletions: f.deletions,
+            language: f.language,
+          })),
+          totalFiles: payload.diffSet.files.length,
+        };
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "get_file_diff",
+    "Get the diff hunks for a specific file in the active review session. Returns the file's changes (additions, deletions, hunks with line-level detail) and its briefing categorization. Use this to focus on one file at a time.",
+    {
+      file: z.string().describe("File path within the diff (e.g., 'src/index.ts')"),
+      session_id: z
+        .string()
+        .optional()
+        .describe("Review session ID. If omitted, uses the most recently created session."),
+    },
+    async ({ file, session_id }) => {
+      try {
+        const sessionId = session_id ?? lastGlobalSessionId;
+        if (!sessionId) {
+          return {
+            content: [{ type: "text" as const, text: "No session ID provided and no recent session available." }],
+            isError: true,
+          };
+        }
+
+        const serverInfo = await isServerAlive();
+        if (!serverInfo) {
+          return {
+            content: [{ type: "text" as const, text: "No global server running." }],
+            isError: true,
+          };
+        }
+
+        const response = await fetch(
+          `http://localhost:${serverInfo.httpPort}/api/reviews/${sessionId}/payload`,
+        );
+        if (!response.ok) {
+          return {
+            content: [{ type: "text" as const, text: `Session not found: ${sessionId}` }],
+            isError: true,
+          };
+        }
+
+        const data = await response.json() as {
+          payload: {
+            diffSet: { files: Array<{ path: string; status: string; additions: number; deletions: number; language: string; hunks: unknown[]; oldPath?: string }> };
+            briefing: { triage: { critical: Array<{ file: string }>; notable: Array<{ file: string }>; mechanical: Array<{ file: string }> }; fileStats: Array<{ path: string; language: string; status: string; additions: number; deletions: number }> };
+          };
+        };
+
+        const diffFile = data.payload.diffSet.files.find((f) => f.path === file);
+        if (!diffFile) {
+          const available = data.payload.diffSet.files.map((f) => f.path);
+          return {
+            content: [{ type: "text" as const, text: `File not found in diff: "${file}". Available files:\n${available.join("\n")}` }],
+            isError: true,
+          };
+        }
+
+        // Determine triage category
+        const { triage } = data.payload.briefing;
+        let category = "mechanical";
+        if (triage.critical.some((c: { file: string }) => c.file === file)) category = "critical";
+        else if (triage.notable.some((n: { file: string }) => n.file === file)) category = "notable";
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({
+            path: diffFile.path,
+            oldPath: diffFile.oldPath,
+            status: diffFile.status,
+            language: diffFile.language,
+            additions: diffFile.additions,
+            deletions: diffFile.deletions,
+            triageCategory: category,
+            hunks: diffFile.hunks,
+          }, null, 2) }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "get_file_context",
+    "Get the full content of a file from the local repository. Uses `git show` to read the file at the PR's head branch without switching branches. Requires the review session to be connected to a local repo (server must be running from within the repo clone).",
+    {
+      file: z.string().describe("File path relative to repo root (e.g., 'src/index.ts')"),
+      ref: z
+        .string()
+        .optional()
+        .describe("Git ref to read from (e.g., 'origin/main', 'HEAD'). Defaults to the PR's head branch if available, otherwise HEAD."),
+      session_id: z
+        .string()
+        .optional()
+        .describe("Review session ID. If omitted, uses the most recently created session."),
+    },
+    async ({ file, ref, session_id }) => {
+      try {
+        const sessionId = session_id ?? lastGlobalSessionId;
+        if (!sessionId) {
+          return {
+            content: [{ type: "text" as const, text: "No session ID provided and no recent session available." }],
+            isError: true,
+          };
+        }
+
+        const serverInfo = await isServerAlive();
+        if (!serverInfo) {
+          return {
+            content: [{ type: "text" as const, text: "No global server running." }],
+            isError: true,
+          };
+        }
+
+        const response = await fetch(
+          `http://localhost:${serverInfo.httpPort}/api/reviews/${sessionId}/payload`,
+        );
+        if (!response.ok) {
+          return {
+            content: [{ type: "text" as const, text: `Session not found: ${sessionId}` }],
+            isError: true,
+          };
+        }
+
+        const data = await response.json() as {
+          projectPath: string;
+          payload: { metadata: { githubPr?: { headBranch: string } } };
+        };
+
+        if (data.projectPath.startsWith("github:")) {
+          return {
+            content: [{ type: "text" as const, text: "No local repo connected. Run the server from within a local clone of the repository to enable file context." }],
+            isError: true,
+          };
+        }
+
+        // Determine the ref to read from
+        const gitRef = ref ?? (data.payload.metadata.githubPr?.headBranch
+          ? `origin/${data.payload.metadata.githubPr.headBranch}`
+          : "HEAD");
+
+        const { execSync } = await import("node:child_process");
+
+        let content: string;
+        try {
+          content = execSync(`git show ${gitRef}:${file}`, {
+            cwd: data.projectPath,
+            encoding: "utf-8",
+            stdio: ["pipe", "pipe", "pipe"],
+            maxBuffer: 10 * 1024 * 1024, // 10MB
+          });
+        } catch {
+          // Fallback: try reading from working tree
+          const fs = await import("node:fs");
+          const path = await import("node:path");
+          const filePath = path.join(data.projectPath, file);
+          try {
+            content = fs.readFileSync(filePath, "utf-8");
+          } catch {
+            return {
+              content: [{ type: "text" as const, text: `File not found: "${file}" (tried git show ${gitRef}:${file} and working tree)` }],
+              isError: true,
+            };
+          }
+        }
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({
+            file,
+            ref: gitRef,
+            projectPath: data.projectPath,
+            content,
+            lineCount: content.split("\n").length,
+          }, null, 2) }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "add_review_comment",
+    "Post a review comment to the active session. The comment appears in the DiffPrism browser UI in real-time as an inline annotation on the diff. Use this to leave findings, suggestions, or questions about specific lines of code.",
+    {
+      file: z.string().describe("File path within the diff"),
+      line: z.number().describe("Line number to comment on"),
+      body: z.string().describe("The comment text"),
+      type: z
+        .enum(["comment", "suggestion", "concern"])
+        .optional()
+        .describe("Type of comment (default: 'comment')"),
+      session_id: z
+        .string()
+        .optional()
+        .describe("Review session ID. If omitted, uses the most recently created session."),
+    },
+    async ({ file, line, body, type, session_id }) => {
+      try {
+        const sessionId = session_id ?? lastGlobalSessionId;
+        if (!sessionId) {
+          return {
+            content: [{ type: "text" as const, text: "No session ID provided and no recent session available." }],
+            isError: true,
+          };
+        }
+
+        const serverInfo = await isServerAlive();
+        if (!serverInfo) {
+          return {
+            content: [{ type: "text" as const, text: "No global server running." }],
+            isError: true,
+          };
+        }
+
+        // Map comment type to annotation type
+        const annotationType = type === "concern" ? "warning" : type === "suggestion" ? "suggestion" : "finding";
+
+        const response = await fetch(
+          `http://localhost:${serverInfo.httpPort}/api/reviews/${sessionId}/annotations`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              file,
+              line,
+              body,
+              type: annotationType,
+              confidence: 1,
+              category: "other",
+              source: {
+                agent: "ai-reviewer",
+                tool: "add_review_comment",
+              },
+            }),
+          },
+        );
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          return {
+            content: [{ type: "text" as const, text: `Error: ${(errorData as Record<string, string>).error ?? `Server returned ${response.status}`}` }],
+            isError: true,
+          };
+        }
+
+        const data = (await response.json()) as { annotationId: string };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ annotationId: data.annotationId, sessionId }, null, 2) }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "get_review_comments",
+    "Get all comments and annotations on the active review session. Returns findings from agents and inline comments from human reviewers. Use this to see what has already been noted before adding your own comments.",
+    {
+      session_id: z
+        .string()
+        .optional()
+        .describe("Review session ID. If omitted, uses the most recently created session."),
+    },
+    async ({ session_id }) => {
+      try {
+        const sessionId = session_id ?? lastGlobalSessionId;
+        if (!sessionId) {
+          return {
+            content: [{ type: "text" as const, text: "No session ID provided and no recent session available." }],
+            isError: true,
+          };
+        }
+
+        const serverInfo = await isServerAlive();
+        if (!serverInfo) {
+          return {
+            content: [{ type: "text" as const, text: "No global server running." }],
+            isError: true,
+          };
+        }
+
+        const response = await fetch(
+          `http://localhost:${serverInfo.httpPort}/api/reviews/${sessionId}/annotations`,
+        );
+        if (!response.ok) {
+          return {
+            content: [{ type: "text" as const, text: `Session not found: ${sessionId}` }],
+            isError: true,
+          };
+        }
+
+        const data = (await response.json()) as { annotations: unknown[] };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ sessionId, annotations: data.annotations }, null, 2) }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "get_user_focus",
+    "Get what the user is currently looking at in the DiffPrism review UI. Returns the file they have selected and any line range they are focused on. Use this to provide context-aware help — answer questions about the code the user is actively reviewing.",
+    {
+      session_id: z
+        .string()
+        .optional()
+        .describe("Review session ID. If omitted, uses the most recently created session."),
+    },
+    async ({ session_id }) => {
+      try {
+        const sessionId = session_id ?? lastGlobalSessionId;
+        if (!sessionId) {
+          return {
+            content: [{ type: "text" as const, text: "No session ID provided and no recent session available." }],
+            isError: true,
+          };
+        }
+
+        const serverInfo = await isServerAlive();
+        if (!serverInfo) {
+          return {
+            content: [{ type: "text" as const, text: "No global server running." }],
+            isError: true,
+          };
+        }
+
+        const response = await fetch(
+          `http://localhost:${serverInfo.httpPort}/api/reviews/${sessionId}/focus`,
+        );
+        if (!response.ok) {
+          return {
+            content: [{ type: "text" as const, text: `Session not found: ${sessionId}` }],
+            isError: true,
+          };
+        }
+
+        const data = (await response.json()) as { focus: { file: string | null; lineStart?: number; lineEnd?: number; updatedAt: number } | null };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ sessionId, ...data }, null, 2) }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -15,13 +15,7 @@ import { getDiff } from "@diffprism/git";
 import { analyze } from "@diffprism/analysis";
 import {
   isPrRef,
-  resolveGitHubToken,
   parsePrRef,
-  createGitHubClient,
-  fetchPullRequest,
-  fetchPullRequestDiff,
-  normalizePr,
-  submitGitHubReview,
 } from "@diffprism/github";
 
 declare const DIFFPRISM_VERSION: string;
@@ -105,98 +99,82 @@ async function handlePrReview(
     timeoutMs?: number;
   },
 ): Promise<{ mcpResult: McpToolResult; sessionId: string; serverInfo: GlobalServerInfo }> {
-  // 1. Resolve GitHub token
-  const token = resolveGitHubToken();
-
-  // 2. Parse PR ref
   const { owner, repo, number } = parsePrRef(pr);
 
-  // 3. Fetch PR data
-  const client = createGitHubClient(token);
-  const [prMetadata, rawDiff] = await Promise.all([
-    fetchPullRequest(client, owner, repo, number),
-    fetchPullRequestDiff(client, owner, repo, number),
-  ]);
-
-  if (!rawDiff.trim()) {
-    return {
-      mcpResult: {
-        content: [{
-          type: "text" as const,
-          text: JSON.stringify({
-            decision: "approved",
-            comments: [],
-            summary: "PR has no changes to review.",
-          }, null, 2),
-        }],
-      },
-      sessionId: "",
-      serverInfo: { httpPort: 0, wsPort: 0, pid: 0, startedAt: 0 },
-    };
-  }
-
-  // 4. Normalize to DiffPrism types
-  const { payload } = normalizePr(rawDiff, prMetadata, {
-    title: options.title,
-    reasoning: options.reasoning,
-  });
-
-  // 5. Route through global server (auto-start if needed)
+  // Auto-start server, then use /api/pr/open for local repo auto-detection
   const serverInfo = await ensureServer({ silent: true });
-  const { result, sessionId } = await submitReviewToServer(
-    serverInfo,
-    `PR #${number}`,
+
+  const response = await fetch(
+    `http://localhost:${serverInfo.httpPort}/api/pr/open`,
     {
-      injectedPayload: payload,
-      projectPath: `github:${owner}/${repo}`,
-      diffRef: `PR #${number}`,
-      timeoutMs: options.timeoutMs ?? 0,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prUrl: pr }),
     },
   );
 
-  // Non-blocking: return session info immediately
-  if (!result) {
+  const data = await response.json() as {
+    sessionId?: string;
+    fileCount?: number;
+    localRepoPath?: string | null;
+    pr?: { title: string; author: string; url: string };
+    error?: string;
+  };
+
+  if (!response.ok || !data.sessionId) {
     return {
       mcpResult: {
-        content: [{
-          type: "text" as const,
-          text: JSON.stringify({
-            status: "session_created",
-            sessionId,
-            pr: `${owner}/${repo}#${number}`,
-            message: "Review session opened in DiffPrism dashboard. Use get_review_result to check for a decision.",
-          }, null, 2),
-        }],
+        content: [{ type: "text" as const, text: `Error: ${data.error ?? "Failed to open PR"}` }],
+        isError: true,
       },
-      sessionId,
+      sessionId: "",
       serverInfo,
     };
   }
 
-  // 6. Optionally post review back to GitHub
-  if ((options.post_to_github || result.postToGithub) && result.decision !== "dismissed") {
-    const posted = await submitGitHubReview(client, owner, repo, number, result);
-    if (posted) {
-      return {
-        mcpResult: {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify({
-              ...result,
-              githubReviewId: posted.reviewId,
-              githubReviewUrl: `${prMetadata.url}#pullrequestreview-${posted.reviewId}`,
-            }, null, 2),
-          }],
-        },
-        sessionId,
-        serverInfo,
-      };
+  const sessionId = data.sessionId;
+
+  // If caller wants to block, poll for result
+  if (options.timeoutMs && options.timeoutMs > 0) {
+    const start = Date.now();
+    while (Date.now() - start < options.timeoutMs) {
+      const resultResponse = await fetch(
+        `http://localhost:${serverInfo.httpPort}/api/reviews/${sessionId}/result`,
+      );
+      if (resultResponse.ok) {
+        const resultData = (await resultResponse.json()) as {
+          result: import("@diffprism/core").ReviewResult | null;
+          status: string;
+        };
+        if (resultData.result) {
+          return {
+            mcpResult: {
+              content: [{ type: "text" as const, text: JSON.stringify(resultData.result, null, 2) }],
+            },
+            sessionId,
+            serverInfo,
+          };
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2000));
     }
   }
 
+  // Non-blocking: return session info
   return {
     mcpResult: {
-      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify({
+          status: "session_created",
+          sessionId,
+          pr: `${owner}/${repo}#${number}`,
+          fileCount: data.fileCount,
+          localRepoConnected: !!data.localRepoPath,
+          localRepoPath: data.localRepoPath,
+          message: "PR review session opened in DiffPrism. Use get_pr_context, get_file_diff, get_file_context to explore the changes. Use add_review_comment to post findings.",
+        }, null, 2),
+      }],
     },
     sessionId,
     serverInfo,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -30,6 +30,45 @@ type McpToolResult = {
   isError?: boolean;
 };
 
+interface SessionSummary {
+  id: string;
+  projectPath: string;
+  title?: string;
+  status: string;
+  createdAt: number;
+}
+
+/**
+ * Resolve a session ID for the super review tools.
+ * Priority: explicit session_id > lastGlobalSessionId > most recent session from server.
+ * This ensures tools work even when the PR was opened by the CLI (not the MCP server).
+ */
+async function resolveSessionId(
+  explicitId: string | undefined,
+  serverInfo: GlobalServerInfo,
+): Promise<string | null> {
+  if (explicitId) return explicitId;
+  if (lastGlobalSessionId) return lastGlobalSessionId;
+
+  // Query server for the most recent session
+  try {
+    const response = await fetch(
+      `http://localhost:${serverInfo.httpPort}/api/reviews`,
+    );
+    if (response.ok) {
+      const data = (await response.json()) as { sessions: SessionSummary[] };
+      if (data.sessions.length > 0) {
+        // Return the most recently created session
+        const sorted = [...data.sessions].sort((a, b) => b.createdAt - a.createdAt);
+        return sorted[0].id;
+      }
+    }
+  } catch {
+    // Server unreachable
+  }
+  return null;
+}
+
 async function handleLocalReview(
   diffRef: string,
   options: {
@@ -915,18 +954,18 @@ export async function startMcpServer(): Promise<void> {
     },
     async ({ session_id }) => {
       try {
-        const sessionId = session_id ?? lastGlobalSessionId;
-        if (!sessionId) {
-          return {
-            content: [{ type: "text" as const, text: "No session ID provided and no recent session available. Open a PR review first." }],
-            isError: true,
-          };
-        }
-
         const serverInfo = await isServerAlive();
         if (!serverInfo) {
           return {
             content: [{ type: "text" as const, text: "No global server running. Start one with `diffprism server`." }],
+            isError: true,
+          };
+        }
+
+        const sessionId = await resolveSessionId(session_id, serverInfo);
+        if (!sessionId) {
+          return {
+            content: [{ type: "text" as const, text: "No review session found. Open a PR review first with `diffprism review <PR URL>`." }],
             isError: true,
           };
         }
@@ -991,18 +1030,18 @@ export async function startMcpServer(): Promise<void> {
     },
     async ({ file, session_id }) => {
       try {
-        const sessionId = session_id ?? lastGlobalSessionId;
-        if (!sessionId) {
+        const serverInfo = await isServerAlive();
+        if (!serverInfo) {
           return {
-            content: [{ type: "text" as const, text: "No session ID provided and no recent session available." }],
+            content: [{ type: "text" as const, text: "No global server running. Start one with `diffprism server`." }],
             isError: true,
           };
         }
 
-        const serverInfo = await isServerAlive();
-        if (!serverInfo) {
+        const sessionId = await resolveSessionId(session_id, serverInfo);
+        if (!sessionId) {
           return {
-            content: [{ type: "text" as const, text: "No global server running." }],
+            content: [{ type: "text" as const, text: "No review session found. Open a PR review first with `diffprism review <PR URL>`." }],
             isError: true,
           };
         }
@@ -1077,18 +1116,18 @@ export async function startMcpServer(): Promise<void> {
     },
     async ({ file, ref, session_id }) => {
       try {
-        const sessionId = session_id ?? lastGlobalSessionId;
-        if (!sessionId) {
+        const serverInfo = await isServerAlive();
+        if (!serverInfo) {
           return {
-            content: [{ type: "text" as const, text: "No session ID provided and no recent session available." }],
+            content: [{ type: "text" as const, text: "No global server running. Start one with `diffprism server`." }],
             isError: true,
           };
         }
 
-        const serverInfo = await isServerAlive();
-        if (!serverInfo) {
+        const sessionId = await resolveSessionId(session_id, serverInfo);
+        if (!sessionId) {
           return {
-            content: [{ type: "text" as const, text: "No global server running." }],
+            content: [{ type: "text" as const, text: "No review session found. Open a PR review first with `diffprism review <PR URL>`." }],
             isError: true,
           };
         }
@@ -1182,18 +1221,18 @@ export async function startMcpServer(): Promise<void> {
     },
     async ({ file, line, body, type, session_id }) => {
       try {
-        const sessionId = session_id ?? lastGlobalSessionId;
-        if (!sessionId) {
+        const serverInfo = await isServerAlive();
+        if (!serverInfo) {
           return {
-            content: [{ type: "text" as const, text: "No session ID provided and no recent session available." }],
+            content: [{ type: "text" as const, text: "No global server running. Start one with `diffprism server`." }],
             isError: true,
           };
         }
 
-        const serverInfo = await isServerAlive();
-        if (!serverInfo) {
+        const sessionId = await resolveSessionId(session_id, serverInfo);
+        if (!sessionId) {
           return {
-            content: [{ type: "text" as const, text: "No global server running." }],
+            content: [{ type: "text" as const, text: "No review session found. Open a PR review first with `diffprism review <PR URL>`." }],
             isError: true,
           };
         }
@@ -1254,18 +1293,18 @@ export async function startMcpServer(): Promise<void> {
     },
     async ({ session_id }) => {
       try {
-        const sessionId = session_id ?? lastGlobalSessionId;
-        if (!sessionId) {
+        const serverInfo = await isServerAlive();
+        if (!serverInfo) {
           return {
-            content: [{ type: "text" as const, text: "No session ID provided and no recent session available." }],
+            content: [{ type: "text" as const, text: "No global server running. Start one with `diffprism server`." }],
             isError: true,
           };
         }
 
-        const serverInfo = await isServerAlive();
-        if (!serverInfo) {
+        const sessionId = await resolveSessionId(session_id, serverInfo);
+        if (!sessionId) {
           return {
-            content: [{ type: "text" as const, text: "No global server running." }],
+            content: [{ type: "text" as const, text: "No review session found. Open a PR review first with `diffprism review <PR URL>`." }],
             isError: true,
           };
         }
@@ -1305,18 +1344,18 @@ export async function startMcpServer(): Promise<void> {
     },
     async ({ session_id }) => {
       try {
-        const sessionId = session_id ?? lastGlobalSessionId;
-        if (!sessionId) {
+        const serverInfo = await isServerAlive();
+        if (!serverInfo) {
           return {
-            content: [{ type: "text" as const, text: "No session ID provided and no recent session available." }],
+            content: [{ type: "text" as const, text: "No global server running. Start one with `diffprism server`." }],
             isError: true,
           };
         }
 
-        const serverInfo = await isServerAlive();
-        if (!serverInfo) {
+        const sessionId = await resolveSessionId(session_id, serverInfo);
+        if (!sessionId) {
           return {
-            content: [{ type: "text" as const, text: "No global server running." }],
+            content: [{ type: "text" as const, text: "No review session found. Open a PR review first with `diffprism review <PR URL>`." }],
             isError: true,
           };
         }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useWebSocket } from "./hooks/useWebSocket";
 import { useNotifications } from "./hooks/useNotifications";
+import { useFocusReporter } from "./hooks/useFocusReporter";
 import { useReviewStore } from "./store/review";
 import { ReviewView } from "./components/ReviewView";
 import { Dashboard } from "./components/Dashboard";
@@ -27,6 +28,9 @@ export default function App() {
   } = useReviewStore();
   const [submitted, setSubmitted] = useState(false);
   const [countdown, setCountdown] = useState(3);
+
+  // Report file focus to server for MCP get_user_focus tool
+  useFocusReporter();
 
   // Sync dark class on <html> with store theme
   useEffect(() => {

--- a/packages/ui/src/components/Dashboard/Dashboard.tsx
+++ b/packages/ui/src/components/Dashboard/Dashboard.tsx
@@ -1,9 +1,10 @@
 import { SessionSidebar } from "../SessionSidebar";
 import { ReviewView } from "../ReviewView";
 import { NotificationToggle } from "../NotificationToggle";
+import { PrInput } from "../PrInput";
 import type { NotificationPermission } from "../../hooks/useNotifications";
 import type { ReviewResult, SessionSummary } from "../../types";
-import { FileCode, Terminal, Settings, FolderOpen, Folder, ChevronUp, GitBranch } from "lucide-react";
+import { FileCode, Terminal, Settings, FolderOpen, Folder, ChevronUp, GitBranch, GitPullRequest } from "lucide-react";
 import { useState, useEffect, useCallback } from "react";
 
 const DIFF_REF_OPTIONS = [
@@ -212,6 +213,8 @@ function OpenProjectForm({ onSuccess }: OpenProjectFormProps) {
   );
 }
 
+type DetailPaneView = "none" | "open-project" | "review-pr";
+
 export function Dashboard({
   sessions,
   activeSessionId,
@@ -224,7 +227,7 @@ export function Dashboard({
   notificationsEnabled,
   onToggleNotifications,
 }: DashboardProps) {
-  const [showOpenProject, setShowOpenProject] = useState(false);
+  const [detailView, setDetailView] = useState<DetailPaneView>("none");
 
   return (
     <div className="h-screen flex bg-background">
@@ -235,7 +238,8 @@ export function Dashboard({
           activeSessionId={activeSessionId}
           onSelect={onSelectSession}
           onClose={onCloseSession}
-          onOpenProject={() => setShowOpenProject(true)}
+          onOpenProject={() => setDetailView("open-project")}
+          onReviewPr={() => setDetailView("review-pr")}
         />
         {/* Notification toggle at bottom of sidebar */}
         {onToggleNotifications && notificationPermission && (
@@ -259,7 +263,7 @@ export function Dashboard({
             watchSubmitted={false}
             hasUnreviewedChanges={true}
           />
-        ) : showOpenProject ? (
+        ) : detailView === "open-project" ? (
           <div className="flex flex-col items-center justify-center h-full px-8">
             <div className="max-w-sm w-full">
               <div className="flex items-center gap-2 mb-4">
@@ -267,10 +271,28 @@ export function Dashboard({
                 <h2 className="text-text-primary text-lg font-semibold">Open Project</h2>
               </div>
               <div className="bg-surface border border-border rounded-lg p-5">
-                <OpenProjectForm onSuccess={() => setShowOpenProject(false)} />
+                <OpenProjectForm onSuccess={() => setDetailView("none")} />
               </div>
               <button
-                onClick={() => setShowOpenProject(false)}
+                onClick={() => setDetailView("none")}
+                className="mt-3 text-text-secondary text-xs hover:text-text-primary transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : detailView === "review-pr" ? (
+          <div className="flex flex-col items-center justify-center h-full px-8">
+            <div className="max-w-sm w-full">
+              <div className="flex items-center gap-2 mb-4">
+                <GitPullRequest className="w-5 h-5 text-accent" />
+                <h2 className="text-text-primary text-lg font-semibold">Review PR</h2>
+              </div>
+              <div className="bg-surface border border-border rounded-lg p-5">
+                <PrInput onSuccess={() => setDetailView("none")} />
+              </div>
+              <button
+                onClick={() => setDetailView("none")}
                 className="mt-3 text-text-secondary text-xs hover:text-text-primary transition-colors"
               >
                 Cancel
@@ -278,14 +300,18 @@ export function Dashboard({
             </div>
           </div>
         ) : (
-          <EmptyDetailPane hasAnySessions={sessions.length > 0} onOpenProject={() => setShowOpenProject(true)} />
+          <EmptyDetailPane
+            hasAnySessions={sessions.length > 0}
+            onOpenProject={() => setDetailView("open-project")}
+            onReviewPr={() => setDetailView("review-pr")}
+          />
         )}
       </div>
     </div>
   );
 }
 
-function EmptyDetailPane({ hasAnySessions, onOpenProject }: { hasAnySessions: boolean; onOpenProject: () => void }) {
+function EmptyDetailPane({ hasAnySessions, onOpenProject, onReviewPr }: { hasAnySessions: boolean; onOpenProject: () => void; onReviewPr: () => void }) {
   if (hasAnySessions) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-center px-8">
@@ -298,21 +324,30 @@ function EmptyDetailPane({ hasAnySessions, onOpenProject }: { hasAnySessions: bo
         <p className="text-text-secondary text-sm max-w-sm mb-4">
           Click a session in the sidebar to view its diff, annotations, and submit your review.
         </p>
-        <button
-          onClick={onOpenProject}
-          className="flex items-center gap-1.5 text-accent text-xs font-medium hover:text-accent/80 transition-colors"
-        >
-          <FolderOpen className="w-3.5 h-3.5" />
-          Open Project
-        </button>
+        <div className="flex items-center gap-4">
+          <button
+            onClick={onReviewPr}
+            className="flex items-center gap-1.5 text-accent text-xs font-medium hover:text-accent/80 transition-colors"
+          >
+            <GitPullRequest className="w-3.5 h-3.5" />
+            Review PR
+          </button>
+          <button
+            onClick={onOpenProject}
+            className="flex items-center gap-1.5 text-text-secondary text-xs font-medium hover:text-text-primary transition-colors"
+          >
+            <FolderOpen className="w-3.5 h-3.5" />
+            Open Project
+          </button>
+        </div>
       </div>
     );
   }
 
-  return <OnboardingPane onOpenProject={onOpenProject} />;
+  return <OnboardingPane onOpenProject={onOpenProject} onReviewPr={onReviewPr} />;
 }
 
-function OnboardingPane({ onOpenProject }: { onOpenProject: () => void }) {
+function OnboardingPane({ onOpenProject, onReviewPr }: { onOpenProject: () => void; onReviewPr: () => void }) {
   const [serverStatus, setServerStatus] = useState<{
     pid: number;
     uptime: number;
@@ -350,14 +385,23 @@ function OnboardingPane({ onOpenProject }: { onOpenProject: () => void }) {
           </p>
         </div>
 
-        {/* Open Project button */}
-        <button
-          onClick={onOpenProject}
-          className="w-full flex items-center justify-center gap-2 bg-accent/15 text-accent text-sm font-medium rounded-lg px-4 py-3 hover:bg-accent/25 transition-colors mb-4"
-        >
-          <FolderOpen className="w-4 h-4" />
-          Open Project
-        </button>
+        {/* Action buttons */}
+        <div className="flex gap-3 mb-4">
+          <button
+            onClick={onReviewPr}
+            className="flex-1 flex items-center justify-center gap-2 bg-accent/15 text-accent text-sm font-medium rounded-lg px-4 py-3 hover:bg-accent/25 transition-colors"
+          >
+            <GitPullRequest className="w-4 h-4" />
+            Review PR
+          </button>
+          <button
+            onClick={onOpenProject}
+            className="flex-1 flex items-center justify-center gap-2 bg-surface border border-border text-text-primary text-sm font-medium rounded-lg px-4 py-3 hover:bg-border/30 transition-colors"
+          >
+            <FolderOpen className="w-4 h-4" />
+            Open Project
+          </button>
+        </div>
 
         {/* Getting Started card */}
         <div className="bg-surface border border-border rounded-lg p-6">

--- a/packages/ui/src/components/DiffViewer/DiffViewer.tsx
+++ b/packages/ui/src/components/DiffViewer/DiffViewer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, useEffect, useRef, type ReactNode } from "react";
+import { useMemo, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import {
   parseDiff,
   Diff,
@@ -12,7 +12,7 @@ import {
 import type { ChangeData, HunkData, GutterOptions, ChangeEventArgs, EventMap } from "react-diff-view";
 import { refractor } from "refractor";
 import { useReviewStore } from "../../store/review";
-import { FileCode, Columns2, Rows2, HelpCircle, Lightbulb } from "lucide-react";
+import { FileCode, Columns2, Rows2, HelpCircle, Lightbulb, Sparkles } from "lucide-react";
 import { InlineCommentForm, InlineCommentThread, InlineAnnotationThread } from "../InlineComment";
 import { ThemeToggle } from "../ThemeToggle";
 import { getFileKey, getDisplayPath } from "../../lib/file-key";
@@ -294,6 +294,30 @@ export function DiffViewer() {
     [activeCommentKey, setActiveCommentKey],
   );
 
+  // "Ask AI" clipboard state
+  const [copiedLine, setCopiedLine] = useState<number | null>(null);
+
+  const handleAskAi = useCallback(
+    (line: number, change: ChangeData, e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!selectedFile) return;
+
+      // Get the content of the change
+      const content = "content" in change ? (change as ChangeData & { content: string }).content : "";
+      const changeType = isInsert(change) ? "added" : isDelete(change) ? "deleted" : "context";
+
+      const prompt = `Look at line ${line} of ${selectedFile} in the current PR review session (${changeType} line: \`${content.trim()}\`). Use get_file_diff and get_file_context to understand the full change, then explain what this code does and whether it looks correct.`;
+
+      navigator.clipboard.writeText(prompt).then(() => {
+        setCopiedLine(line);
+        setTimeout(() => setCopiedLine(null), 2000);
+      }).catch(() => {
+        // Clipboard API not available
+      });
+    },
+    [selectedFile],
+  );
+
   // Custom gutter renderer — show "+" on hover, indicators for comments/annotations
   const renderGutter = useCallback(
     ({ change, inHoverState, renderDefault }: GutterOptions) => {
@@ -307,6 +331,13 @@ export function DiffViewer() {
         return (
           <>
             <span className="diff-gutter-add-comment">+</span>
+            <span
+              className="diff-gutter-ask-ai"
+              title={copiedLine === line ? "Copied!" : "Ask AI about this line"}
+              onClick={(e) => handleAskAi(line, change, e)}
+            >
+              {copiedLine === line ? "!" : "?"}
+            </span>
             {renderDefault()}
           </>
         );
@@ -332,7 +363,7 @@ export function DiffViewer() {
 
       return renderDefault();
     },
-    [selectedFile, fileComments, annotationsByLine],
+    [selectedFile, fileComments, annotationsByLine, copiedLine, handleAskAi],
   );
 
   // Build widgets — inline comment threads, annotation threads, and/or open forms

--- a/packages/ui/src/components/DiffViewer/DiffViewer.tsx
+++ b/packages/ui/src/components/DiffViewer/DiffViewer.tsx
@@ -180,7 +180,10 @@ export function DiffViewer() {
     setHunkCount,
     annotations,
     dismissAnnotation,
+    metadata,
   } = useReviewStore();
+
+  const isPrReview = !!metadata?.githubPr;
 
   const selectedDiffFile = useMemo(() => {
     if (!diffSet || !selectedFile) return null;
@@ -282,16 +285,16 @@ export function DiffViewer() {
     return map;
   }, [fileAnnotations]);
 
-  // Gutter click handler — toggle comment form for the clicked line
+  // Gutter click handler — toggle comment form for the clicked line (disabled for PR reviews)
   const gutterEvents: EventMap = useMemo(
-    () => ({
+    () => isPrReview ? {} : ({
       onClick({ change }: ChangeEventArgs) {
         if (!change) return;
         const key = getChangeKey(change);
         setActiveCommentKey(activeCommentKey === key ? null : key);
       },
     }),
-    [activeCommentKey, setActiveCommentKey],
+    [activeCommentKey, setActiveCommentKey, isPrReview],
   );
 
   // Custom gutter renderer — show "+" on hover, indicators for comments/annotations
@@ -299,11 +302,11 @@ export function DiffViewer() {
     ({ change, inHoverState, renderDefault }: GutterOptions) => {
       const line = getLineFromChange(change);
       const hasComments =
-        selectedFile &&
+        !isPrReview && selectedFile &&
         fileComments.some((c) => c.comment.line === line);
       const hasAnnotations = annotationsByLine.has(line);
 
-      if (inHoverState) {
+      if (inHoverState && !isPrReview) {
         return (
           <>
             <span className="diff-gutter-add-comment">+</span>
@@ -332,20 +335,22 @@ export function DiffViewer() {
 
       return renderDefault();
     },
-    [selectedFile, fileComments, annotationsByLine],
+    [selectedFile, fileComments, annotationsByLine, isPrReview],
   );
 
-  // Build widgets — inline comment threads, annotation threads, and/or open forms
+  // Build widgets — inline annotation threads (+ comment threads for non-PR reviews)
   const widgets = useMemo(() => {
     if (!selectedFile) return {};
     const w: Record<string, ReactNode> = {};
 
-    // Group file comments by line
+    // Group file comments by line (skip for PR reviews)
     const commentsByLine = new Map<number, { comment: typeof comments[0]; index: number }[]>();
-    for (const fc of fileComments) {
-      const line = fc.comment.line;
-      if (!commentsByLine.has(line)) commentsByLine.set(line, []);
-      commentsByLine.get(line)!.push(fc);
+    if (!isPrReview) {
+      for (const fc of fileComments) {
+        const line = fc.comment.line;
+        if (!commentsByLine.has(line)) commentsByLine.set(line, []);
+        commentsByLine.get(line)!.push(fc);
+      }
     }
 
     // Collect all lines that have either comments or annotations
@@ -370,7 +375,7 @@ export function DiffViewer() {
               onDismiss={dismissAnnotation}
             />
           )}
-          {lineComments && lineComments.length > 0 && (
+          {!isPrReview && lineComments && lineComments.length > 0 && (
             <InlineCommentThread
               comments={lineComments}
               isFormOpen={activeCommentKey === changeKey}
@@ -391,8 +396,8 @@ export function DiffViewer() {
       );
     }
 
-    // Render standalone form for active key with no existing content
-    if (activeCommentKey && !w[activeCommentKey]) {
+    // Render standalone form for active key with no existing content (skip for PR reviews)
+    if (!isPrReview && activeCommentKey && !w[activeCommentKey]) {
       const line = keyToLineMap[activeCommentKey];
       if (line !== undefined) {
         w[activeCommentKey] = (
@@ -425,6 +430,7 @@ export function DiffViewer() {
     deleteComment,
     dismissAnnotation,
     setActiveCommentKey,
+    isPrReview,
   ]);
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);

--- a/packages/ui/src/components/DiffViewer/DiffViewer.tsx
+++ b/packages/ui/src/components/DiffViewer/DiffViewer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { useMemo, useCallback, useEffect, useRef, type ReactNode } from "react";
 import {
   parseDiff,
   Diff,
@@ -12,7 +12,7 @@ import {
 import type { ChangeData, HunkData, GutterOptions, ChangeEventArgs, EventMap } from "react-diff-view";
 import { refractor } from "refractor";
 import { useReviewStore } from "../../store/review";
-import { FileCode, Columns2, Rows2, HelpCircle, Lightbulb, Sparkles } from "lucide-react";
+import { FileCode, Columns2, Rows2, HelpCircle, Lightbulb } from "lucide-react";
 import { InlineCommentForm, InlineCommentThread, InlineAnnotationThread } from "../InlineComment";
 import { ThemeToggle } from "../ThemeToggle";
 import { getFileKey, getDisplayPath } from "../../lib/file-key";
@@ -294,30 +294,6 @@ export function DiffViewer() {
     [activeCommentKey, setActiveCommentKey],
   );
 
-  // "Ask AI" clipboard state
-  const [copiedLine, setCopiedLine] = useState<number | null>(null);
-
-  const handleAskAi = useCallback(
-    (line: number, change: ChangeData, e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (!selectedFile) return;
-
-      // Get the content of the change
-      const content = "content" in change ? (change as ChangeData & { content: string }).content : "";
-      const changeType = isInsert(change) ? "added" : isDelete(change) ? "deleted" : "context";
-
-      const prompt = `Look at line ${line} of ${selectedFile} in the current PR review session (${changeType} line: \`${content.trim()}\`). Use get_file_diff and get_file_context to understand the full change, then explain what this code does and whether it looks correct.`;
-
-      navigator.clipboard.writeText(prompt).then(() => {
-        setCopiedLine(line);
-        setTimeout(() => setCopiedLine(null), 2000);
-      }).catch(() => {
-        // Clipboard API not available
-      });
-    },
-    [selectedFile],
-  );
-
   // Custom gutter renderer — show "+" on hover, indicators for comments/annotations
   const renderGutter = useCallback(
     ({ change, inHoverState, renderDefault }: GutterOptions) => {
@@ -331,13 +307,6 @@ export function DiffViewer() {
         return (
           <>
             <span className="diff-gutter-add-comment">+</span>
-            <span
-              className="diff-gutter-ask-ai"
-              title={copiedLine === line ? "Copied!" : "Ask AI about this line"}
-              onClick={(e) => handleAskAi(line, change, e)}
-            >
-              {copiedLine === line ? "!" : "?"}
-            </span>
             {renderDefault()}
           </>
         );
@@ -363,7 +332,7 @@ export function DiffViewer() {
 
       return renderDefault();
     },
-    [selectedFile, fileComments, annotationsByLine, copiedLine, handleAskAi],
+    [selectedFile, fileComments, annotationsByLine],
   );
 
   // Build widgets — inline comment threads, annotation threads, and/or open forms

--- a/packages/ui/src/components/PrInput/PrInput.tsx
+++ b/packages/ui/src/components/PrInput/PrInput.tsx
@@ -1,0 +1,112 @@
+import { useState, useCallback } from "react";
+import { GitPullRequest, Loader2, ExternalLink } from "lucide-react";
+
+interface PrInputProps {
+  onSuccess?: () => void;
+}
+
+function getHttpPort(): string | null {
+  return new URLSearchParams(window.location.search).get("httpPort");
+}
+
+interface PrOpenResult {
+  sessionId: string;
+  fileCount: number;
+  localRepoPath: string | null;
+  pr: {
+    title: string;
+    author: string;
+    url: string;
+    baseBranch: string;
+    headBranch: string;
+  };
+}
+
+export function PrInput({ onSuccess }: PrInputProps) {
+  const [prUrl, setPrUrl] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = useCallback(async () => {
+    const httpPort = getHttpPort();
+    if (!httpPort || !prUrl.trim()) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`http://localhost:${httpPort}/api/pr/open`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prUrl: prUrl.trim() }),
+      });
+      const data = await res.json() as PrOpenResult & { error?: string };
+
+      if (!res.ok) {
+        setError(data.error ?? "Failed to open PR");
+      } else {
+        setPrUrl("");
+        onSuccess?.();
+      }
+    } catch {
+      setError("Could not connect to server");
+    } finally {
+      setLoading(false);
+    }
+  }, [prUrl, onSuccess]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && !e.shiftKey && prUrl.trim()) {
+        e.preventDefault();
+        handleSubmit();
+      }
+    },
+    [handleSubmit, prUrl],
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="relative">
+        <input
+          type="text"
+          value={prUrl}
+          onChange={(e) => {
+            setPrUrl(e.target.value);
+            if (error) setError(null);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder="https://github.com/owner/repo/pull/123"
+          className="w-full bg-background border border-border rounded-md px-3 py-2 pl-9 text-text-primary text-xs placeholder:text-text-secondary/50 focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent/30 transition-colors"
+          disabled={loading}
+          autoFocus
+        />
+        <GitPullRequest className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-secondary" />
+      </div>
+
+      <button
+        onClick={handleSubmit}
+        disabled={loading || !prUrl.trim()}
+        className="w-full bg-accent/15 text-accent text-xs font-medium rounded-md px-3 py-2 hover:bg-accent/25 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-1.5"
+      >
+        {loading ? (
+          <>
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            Fetching PR...
+          </>
+        ) : (
+          <>
+            <ExternalLink className="w-3.5 h-3.5" />
+            Review PR
+          </>
+        )}
+      </button>
+
+      {error && <p className="text-danger text-xs">{error}</p>}
+
+      <p className="text-text-secondary text-[10px]">
+        Also accepts <code className="text-accent/70">owner/repo#123</code> format
+      </p>
+    </div>
+  );
+}

--- a/packages/ui/src/components/PrInput/index.ts
+++ b/packages/ui/src/components/PrInput/index.ts
@@ -1,0 +1,1 @@
+export { PrInput } from "./PrInput.js";

--- a/packages/ui/src/components/ReviewView.tsx
+++ b/packages/ui/src/components/ReviewView.tsx
@@ -19,7 +19,8 @@ interface ReviewViewProps {
 }
 
 export function ReviewView({ onSubmit, onDismiss, isWatchMode, watchSubmitted, hasUnreviewedChanges }: ReviewViewProps) {
-  const { annotations, dismissAnnotation, selectFile, diffSet } = useReviewStore();
+  const { annotations, dismissAnnotation, selectFile, diffSet, metadata } = useReviewStore();
+  const isPrReview = !!metadata?.githubPr;
 
   // Resolve raw file paths (from annotations) to file keys (which may have stage prefixes)
   const navigateToFile = (filePath: string) => {
@@ -58,14 +59,16 @@ export function ReviewView({ onSubmit, onDismiss, isWatchMode, watchSubmitted, h
         <DiffViewer />
       </div>
 
-      {/* Bottom — Action Bar */}
-      <ActionBar
-        onSubmit={onSubmit}
-        onDismiss={onDismiss}
-        isWatchMode={isWatchMode}
-        watchSubmitted={watchSubmitted}
-        hasUnreviewedChanges={hasUnreviewedChanges}
-      />
+      {/* Bottom — Action Bar (hidden for PR reviews) */}
+      {!isPrReview && (
+        <ActionBar
+          onSubmit={onSubmit}
+          onDismiss={onDismiss}
+          isWatchMode={isWatchMode}
+          watchSubmitted={watchSubmitted}
+          hasUnreviewedChanges={hasUnreviewedChanges}
+        />
+      )}
       <HotkeyGuide />
       <WorkflowTips />
     </div>

--- a/packages/ui/src/components/SessionSidebar/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar/SessionSidebar.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, Clock, X, AlertCircle, FolderOpen, Plus } from "lucide-react";
+import { GitBranch, GitPullRequest, Clock, X, AlertCircle, FolderOpen, Plus } from "lucide-react";
 import type { SessionSummary } from "../../types";
 import { STATUS_BADGE_STYLES } from "../../lib/semantic-colors";
 
@@ -8,6 +8,7 @@ interface SessionSidebarProps {
   onSelect: (sessionId: string) => void;
   onClose: (sessionId: string) => void;
   onOpenProject?: () => void;
+  onReviewPr?: () => void;
 }
 
 function formatRelativeTime(timestamp: number): string {
@@ -24,6 +25,10 @@ function formatRelativeTime(timestamp: number): string {
 }
 
 function getProjectName(projectPath: string): string {
+  // GitHub PR sessions: "github:owner/repo#123" → "owner/repo#123"
+  if (projectPath.startsWith("github:")) {
+    return projectPath.slice(7);
+  }
   const parts = projectPath.split("/");
   return parts[parts.length - 1] || projectPath;
 }
@@ -51,7 +56,7 @@ function statusBadge(session: SessionSummary) {
   );
 }
 
-export function SessionSidebar({ sessions, activeSessionId, onSelect, onClose, onOpenProject }: SessionSidebarProps) {
+export function SessionSidebar({ sessions, activeSessionId, onSelect, onClose, onOpenProject, onReviewPr }: SessionSidebarProps) {
   return (
     <div className="flex flex-col h-full bg-surface border-r border-border">
       {/* Header */}
@@ -64,15 +69,26 @@ export function SessionSidebar({ sessions, activeSessionId, onSelect, onClose, o
             {sessions.length} session{sessions.length !== 1 ? "s" : ""}
           </span>
         </div>
-        {onOpenProject && (
-          <button
-            onClick={onOpenProject}
-            className="p-1 rounded hover:bg-border/50 text-text-secondary hover:text-text-primary transition-colors"
-            title="Open project"
-          >
-            <Plus className="w-3.5 h-3.5" />
-          </button>
-        )}
+        <div className="flex items-center gap-1">
+          {onReviewPr && (
+            <button
+              onClick={onReviewPr}
+              className="p-1 rounded hover:bg-border/50 text-text-secondary hover:text-accent transition-colors"
+              title="Review GitHub PR"
+            >
+              <GitPullRequest className="w-3.5 h-3.5" />
+            </button>
+          )}
+          {onOpenProject && (
+            <button
+              onClick={onOpenProject}
+              className="p-1 rounded hover:bg-border/50 text-text-secondary hover:text-text-primary transition-colors"
+              title="Open project"
+            >
+              <Plus className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Session entries */}
@@ -88,6 +104,7 @@ export function SessionSidebar({ sessions, activeSessionId, onSelect, onClose, o
             {sessions.map((session) => {
               const isActive = session.id === activeSessionId;
               const isManual = session.source === "manual";
+              const isGitHubPr = session.projectPath.startsWith("github:");
 
               return (
                 <div
@@ -125,9 +142,11 @@ export function SessionSidebar({ sessions, activeSessionId, onSelect, onClose, o
                       {session.needsAttention && (
                         <AlertCircle className="w-3.5 h-3.5 text-warning flex-shrink-0 animate-pulse" />
                       )}
-                      {isManual && (
+                      {isGitHubPr ? (
+                        <GitPullRequest className="w-3.5 h-3.5 text-accent flex-shrink-0" />
+                      ) : isManual ? (
                         <FolderOpen className="w-3.5 h-3.5 text-text-secondary flex-shrink-0" />
-                      )}
+                      ) : null}
                       <span className="text-text-primary text-xs font-medium truncate">
                         {session.title || getProjectName(session.projectPath)}
                       </span>

--- a/packages/ui/src/hooks/useFocusReporter.ts
+++ b/packages/ui/src/hooks/useFocusReporter.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+import { useReviewStore } from "../store/review";
+
+/**
+ * Reports the user's current file focus to the server via HTTP.
+ * This enables the `get_user_focus` MCP tool so AI agents
+ * know what the user is looking at.
+ */
+export function useFocusReporter() {
+  const selectedFile = useReviewStore((s) => s.selectedFile);
+  const activeSessionId = useReviewStore((s) => s.activeSessionId);
+  const reviewId = useReviewStore((s) => s.reviewId);
+  const lastReportedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const sessionId = activeSessionId ?? reviewId;
+    if (!sessionId) return;
+
+    const httpPort = new URLSearchParams(window.location.search).get("httpPort");
+    if (!httpPort) return;
+
+    // Avoid duplicate reports
+    const key = `${sessionId}:${selectedFile}`;
+    if (key === lastReportedRef.current) return;
+    lastReportedRef.current = key;
+
+    fetch(`http://localhost:${httpPort}/api/reviews/${sessionId}/focus`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ file: selectedFile }),
+    }).catch(() => {
+      // Best-effort — don't break the UI if the server is unreachable
+    });
+  }, [selectedFile, activeSessionId, reviewId]);
+}

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -410,6 +410,32 @@
   transform: translateY(-50%);
 }
 
+/* Purple "?" button on gutter hover — Ask AI */
+.diff-gutter-ask-ai {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  background-color: var(--color-accent);
+  color: #ffffff;
+  font-size: 10px;
+  font-weight: bold;
+  line-height: 1;
+  position: absolute;
+  left: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  cursor: pointer;
+  opacity: 0.8;
+  transition: opacity 0.15s;
+}
+
+.diff-gutter-ask-ai:hover {
+  opacity: 1;
+}
+
 /* Blue dot for lines with existing comments */
 .diff-comment-indicator {
   display: inline-block;

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -410,31 +410,6 @@
   transform: translateY(-50%);
 }
 
-/* Purple "?" button on gutter hover — Ask AI */
-.diff-gutter-ask-ai {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  border-radius: 3px;
-  background-color: var(--color-accent);
-  color: #ffffff;
-  font-size: 10px;
-  font-weight: bold;
-  line-height: 1;
-  position: absolute;
-  left: 20px;
-  top: 50%;
-  transform: translateY(-50%);
-  cursor: pointer;
-  opacity: 0.8;
-  transition: opacity 0.15s;
-}
-
-.diff-gutter-ask-ai:hover {
-  opacity: 1;
-}
 
 /* Blue dot for lines with existing comments */
 .diff-comment-indicator {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@diffprism/git':
         specifier: workspace:*
         version: link:../git
+      '@diffprism/github':
+        specifier: workspace:*
+        version: link:../github
       get-port:
         specifier: ^7.1.0
         version: 7.1.0


### PR DESCRIPTION
## Summary
- Paste a GitHub PR URL in the DiffPrism UI or run `diffprism review <PR URL>` from the CLI to open a PR for review
- 6 new MCP tools (`get_pr_context`, `get_file_diff`, `get_file_context`, `add_review_comment`, `get_review_comments`, `get_user_focus`) let Claude Code / Cursor interrogate PR changes and post findings to the browser UI in real-time
- Server auto-detects local repo clones via `git remote -v` matching for full file context
- No Anthropic SDK — AI integration is entirely through MCP, plug-and-play with any AI tool
- PR review UI is streamlined: no action bar or inline comment forms (users review on GitHub directly)

## Test plan
- [ ] `pnpm test` — all 343 tests pass
- [ ] `cd` into a local repo clone, run `diffprism server --dev`
- [ ] Paste a PR URL in the Dashboard UI → diff renders with local repo badge
- [ ] Run `diffprism review <PR URL>` from CLI → non-blocking, opens browser
- [ ] In Claude Code: `get_pr_context` → returns PR overview
- [ ] In Claude Code: `get_file_diff` for a file → returns hunks
- [ ] In Claude Code: `get_file_context` → returns full file from local repo
- [ ] In Claude Code: `add_review_comment` → comment appears in browser UI
- [ ] Verify ActionBar is hidden for PR sessions
- [ ] Verify gutter "+" comment button is hidden for PR sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)